### PR TITLE
Remove unused FW airframes

### DIFF
--- a/en/airframes/airframe_reference.md
+++ b/en/airframes/airframe_reference.md
@@ -722,26 +722,6 @@ This page lists all supported airframes and types including
    <tr><th>Name</th><th></th></tr>
  </thead>
 <tbody>
-<tr id="plane_standard_plane_multiplex_easystar">
- <td style="vertical-align: top;">Multiplex Easystar</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2100</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: rudder</li><li><b>MAIN4</b>: throttle</li></ul></p></td>
-
-</tr>
-<tr id="plane_standard_plane_standard_aert_plane">
- <td style="vertical-align: top;">Standard AERT Plane</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2101</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: rudder</li><li><b>MAIN4</b>: throttle</li><li><b>MAIN5</b>: flaps</li></ul></p></td>
-
-</tr>
-<tr id="plane_standard_plane_skywalker_(3dr_aero)">
- <td style="vertical-align: top;">Skywalker (3DR Aero)</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2102</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: throttle</li><li><b>MAIN4</b>: rudder</li><li><b>MAIN5</b>: flaps</li></ul></p></td>
-
-</tr>
-<tr id="plane_standard_plane_skyhunter_1800">
- <td style="vertical-align: top;">Skyhunter 1800</td>
- <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2103</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN4</b>: throttle</li></ul></p></td>
-
-</tr>
 <tr id="plane_standard_plane_standard_aetr_plane">
  <td style="vertical-align: top;">Standard AETR Plane</td>
  <td style="vertical-align: top;"><p>Maintainer: Lorenz Meier <lorenz@px4.io></p><p><code>SYS_AUTOSTART</code> = 2104</p><p><b>Specific Outputs:</b><ul><li><b>MAIN1</b>: aileron</li><li><b>MAIN2</b>: elevator</li><li><b>MAIN3</b>: throttle</li><li><b>MAIN4</b>: rudder</li><li><b>MAIN5</b>: flaps</li></ul></p></td>


### PR DESCRIPTION
The latest version of PX4 only has 2 standard plane airframes available, Standard AETR and Bormatec Maja. This will remove confusion, especially confusing AERT with AETR, which can lead to unsafe accidental arming condition.