### PR TITLE
Fix copypaste error in parameter names

### DIFF
--- a/en/advanced_config/pid_tuning_guide_multicopter.md
+++ b/en/advanced_config/pid_tuning_guide_multicopter.md
@@ -137,7 +137,7 @@ add [MC_ROLLRATE_I](../advanced_config/parameter_reference.md#MC_ROLLRATE_I) and
 
 ### P Gain Tuning
 
-Parameters: [MC_RATE_P](../advanced_config/parameter_reference.md#MC_RATE_P), [MC_RATE_P](../advanced_config/parameter_reference.md#MC_RATE_P).
+Parameters: [MC_ROLL_P](../advanced_config/parameter_reference.md#MC_ROLL_P), [MC_PITCH_P](../advanced_config/parameter_reference.md#MC_PITCH_P).
 
 - Set `MC_ROLL_P` and `MC_PITCH_P` to a small value, e.g. 3
 


### PR DESCRIPTION
The parameter names in the summary for Step 3 weren't the ones referenced in the body text. The body text references were correct.