### PR TITLE
aero: add instructions to use optical flow

### DIFF
--- a/en/flight_controller/intel_aero.md
+++ b/en/flight_controller/intel_aero.md
@@ -93,3 +93,16 @@ The pinout for the Lidar Lite V3 is as follows
 ![](../../assets/hardware/Aero_I2C_splitter.JPG)
 
 ![](../../assets/hardware/Aero_LidarLite.JPG)
+
+## Using Optical Flow on the Aero
+
+The Intel Aero comes with a preinstalled optical flow binary on the compute board (Linux OS version 1.6 or higher) which enables the Aero to stably fly based on optical flow velocity estimation. In order to use optical flow, a range sensor has to be installed first (see above).
+
+To use the optical flow, run the following command in a console on the Aero compute board:
+```
+systemctl start aero-optical-flow
+```
+If you want to start the optical flow binary at boot, use
+```
+systemctl enable aero-optical-flow #use disable to undo
+```

--- a/en/flight_controller/intel_aero.md
+++ b/en/flight_controller/intel_aero.md
@@ -96,7 +96,7 @@ The pinout for the Lidar Lite V3 is as follows
 
 ## Using Optical Flow on the Aero
 
-The Intel Aero comes with a preinstalled optical flow binary on the compute board (Linux OS version 1.6 or higher) which enables the Aero to stably fly based on optical flow velocity estimation. In order to use optical flow, a range sensor has to be installed first (see above).
+The Intel Aero comes with a preinstalled optical flow binary on the compute board (Linux OS version 1.6 or higher), which enables the Aero to stably fly based on optical flow velocity estimation. In order to use optical flow, a range sensor has to be installed first (see above).
 
 To use the optical flow, run the following command in a console on the Aero compute board:
 ```
@@ -106,3 +106,10 @@ If you want to start the optical flow binary at boot, use
 ```
 systemctl enable aero-optical-flow #use disable to undo
 ```
+
+In addition, the following parameter values should be set in the flight controller.
+
+| Parameter     | Value |
+| ------------- | ----- |
+| EKF2_AID_MASK | 2     |
+| EKF2_HGT_MODE | 2     |


### PR DESCRIPTION
@zehortigoza @lucasdemarchi  is v1.6 or higher correct?
We also need to check the PX4 side and the default parameters like `EKF2_AID_MASK`,  `EKF2_HGT_MODE` and `EKF2_RNG_AID` for the next release.