### PR TITLE
Update introductions to airframe builds

### DIFF
--- a/en/airframes/README.md
+++ b/en/airframes/README.md
@@ -1,7 +1,5 @@
-# Framebuilds
+# Airframe/Vehicle Builds
 
-This section contains instructions for how to install 
-autopilot systems for a number of common multicopter, planes and VTOL frames.
+PX4 supports numerous types of vehicles, including different configurations of multicopters, planes, VTOL vehicles, ground vehicles, etc. The complete set of supported configurations can be seen in the [Airframes Reference](../airframes/airframe_reference.md).
 
-The instructions use different [flight controllers](../flight_controller/README.md)
-and sensors in each case.
+This section contains instructions for how to install several different [flight controllers](../flight_controller/README.md) on a number of common frames.

--- a/en/assembly/README.md
+++ b/en/assembly/README.md
@@ -3,4 +3,4 @@
 This section contains assembly and wiring information for a "minimal" autopilot system using the different [flight controllers](../flight_controller/README.md). 
 
 * See [Peripherals](../peripherals/README.md) for information about connecting sensors and other peripherals.
-* See [Specific Vehicle Builds](../airframes/README.md) for complete assembly examples on different vehicle frames.
+* See [Airframe Builds](../airframes/README.md) for complete assembly examples on different vehicle frames.

--- a/en/frames_multicopter/README.md
+++ b/en/frames_multicopter/README.md
@@ -1,4 +1,28 @@
 # Multicopter Frame Builds
 
-This section contains build logs and instructions for assembling 
-and configuring a number of Multicopter frames.
+PX4 supports numerous types of single- and multi-copters, including helicopters, tricopters, quadcopters, hexarotors, dodecarotors etc, in many different geometries (+, wide, x etc.). The complete set of supported configurations can be seen in [Airframes Reference > Copter](../airframes/airframe_reference.md#copter).
+
+This section contains build logs/instructions for assembling and configuring a number of copter frames.
+
+## Videos
+
+{% youtube %}https://www.youtube.com/watch?v=LnUmYgAINBc&vq=hd720{% endyoutube %}
+
+
+DJI Flame Wheel 450 with Distance Sensor and RTK GPS (Pixhawk 3 Pro)
+
+{% youtube %}https://www.youtube.com/watch?v=JovSwzoTepU{% endyoutube %}
+
+Lumenier QAV250 Pixhawk Mini Build
+
+{% youtube %}
+http://www.youtube.com/watch?v=MZzo4DMNkug
+{% endyoutube %}
+
+DJI Matrice 100 (Pixhawk 1)
+
+{% youtube %}https://www.youtube.com/watch?v=3OGs0ONemGc{% endyoutube %}
+
+QAV-R 5" KISS ESC Racer (Pixracer)
+
+{% youtube %}https://www.youtube.com/watch?v=wMYgqvsNEwQ{% endyoutube %}

--- a/en/frames_plane/README.md
+++ b/en/frames_plane/README.md
@@ -1,4 +1,11 @@
 # Plane Frame Builds
 
-This section contains build logs and instructions for assembling 
-and configuring a number of Plane frames.
+PX4 supports every imaginable plane geometry, including normal planes, flying wings, inverted V-tail planes etc. The complete set of supported configurations can be seen in [Airframes Reference > Plane](../airframes/airframe_reference.md#plane).
+
+This section contains build logs/instructions for assembling and configuring a number of Plane frames.
+
+
+## Videos
+
+{% youtube %}https://www.youtube.com/watch?v=8m4_NpTQn0E&vq=hd720{% endyoutube %}
+

--- a/en/frames_rover/README.md
+++ b/en/frames_rover/README.md
@@ -1,8 +1,11 @@
 # Rover Frames (UGVs)
 
-PX4 provides basic support for Unmanned Ground Vehicles (UGVs).
+PX4 provides basic support for Unmanned Ground Vehicles (UGVs). The set of validated configurations can be seen in [Airframes Reference > Rover](../airframes/airframe_reference.md#rover).
 
-Build Logs:
-* [Traxxas Stampede](../frames_rover/traxxas_stampede.md) 
+This section contains build logs/instructions for assembling and configuring a number of UGV frames.
+
+## Videos
+
+[Traxxas Stampede](../frames_rover/traxxas_stampede.md) 
 
 {% youtube %}https://youtu.be/N3HvSKS3nCw{% endyoutube %}

--- a/en/frames_vtol/README.md
+++ b/en/frames_vtol/README.md
@@ -1,6 +1,6 @@
 # VTOL Airframes
 
-PX4 supports virtually all VTOL configurations:
+PX4 supports virtually all VTOL configurations (the complete set of supported configurations can be seen in [Airframes Reference > VTOL](../airframes/airframe_reference.md#vtol)):
 
   * Tailsitters (duo and quadrotors in X and plus configuration)
   * Tiltrotors (Firefly Y6)
@@ -11,38 +11,39 @@ The VTOL codebase is the same codebase as for all other airframes and just adds 
 This section contains build logs and instructions for assembling and configuring a number of VTOL vehicle frames.
 
 
-## Key Configuration Parameters
+## Videos
 
-These configuration parameters have to be set correctly when creating a new airframe configuration.
+### Tailsitter
 
-* [VT_FW_PERM_STAB](../advanced_config/parameter_reference.md#VT_FW_PERM_STAB) the system always uses attitude stabilization in hover mode. If this parameter is set to 1, the plane mode also defaults to attitude stabilization. If it is set to 0, it defaults to pure manual flight.
-* [VT_ARSP_TRANS](../advanced_config/parameter_reference.md#VT_ARSP_TRANS) is the airspeed in m/s at which the plane transitions into forward flight. Setting it too low can cause a stall during the transition.
-* [RC_MAP_TRANS_SW](../advanced_config/parameter_reference.md#RC_MAP_TRANS_SW) should be assigned to a RC switch before flight. This allows you to check if the multicopter- and fixed wing mode work properly. (Can also be used to switch manually between those two control modes during flight)
-
-## Tailsitter
-
-Build Logs:
-* [TBS Caipiroshka](../frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md)
+[TBS Caipiroshka](../frames_vtol/vtol_tailsitter_caipiroshka_pixracer.md)
 
 {% youtube %}https://www.youtube.com/watch?v=acG0aTuf3f8&vq=hd720{% endyoutube %}
 
-## Tiltrotor
+### Tiltrotor
 
-Build Logs:
-* [FireFly Y6 Tiltrotor](../frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.md)
-* [Convergence Tiltrotor](../frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md)
+[FireFly Y6 Tiltrotor](../frames_vtol/vtol_tiltrotor_birdseyeview_firefly_y6_pixfalcon.md)
 
 {% youtube %}https://www.youtube.com/watch?v=Vsgh5XnF44Y&vq=hd720{% endyoutube %}
 
-## QuadPlane VTOL
+[Convergence Tiltrotor](../frames_vtol/vtol_tiltrotor_eflite_convergence_pixfalcon.md)
 
-Build Logs:
-* [Falcon Vertigo QuadPlane](../frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md)
-* [FunCub QuadPlane](../frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md)
-* [Ranger QuadPlane](../frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md)
+{% youtube %} https://youtu.be/E61P2f2WPNU {% endyoutube %}
 
+### QuadPlane VTOL
+
+[FunCub QuadPlane](../frames_vtol/vtol_quadplane_fun_cub_vtol_pixhawk.md)
 
 {% youtube %}https://www.youtube.com/watch?v=4K8yaa6A0ks&vq=hd720{% endyoutube %}
+
+
+
+[Falcon Vertigo QuadPlane](../frames_vtol/vtol_quadplane_falcon_vertigo_hybrid_rtf_dropix.md)
+
+{% youtube %} https://youtu.be/h7OHTigtU0s {% endyoutube %}
+
+
+[Ranger QuadPlane](../frames_vtol/vtol_quadplane_volantex_ranger_ex_pixhawk.md)
+
 
 {% youtube %}https://www.youtube.com/watch?v=7tGXkW6d3sA&vq=hd720{% endyoutube %}
 


### PR DESCRIPTION
This updates the introduction to each airframe build section to explain what the section contains and make it clear that these are subset of supported frames. Also added some videos from the contained docs to prettify the entry points. 