### PR TITLE
AUAV 2 Link fix to mRo x2.1

### DIFF
--- a/en/flight_controller/auav_x2.md
+++ b/en/flight_controller/auav_x2.md
@@ -43,7 +43,7 @@ The [AUAV](http://www.auav.com/) *AUAV-X2 autopilot* is based on the [Pixhawk-pr
 
 ## Availability
 
-No longer in production. Successor is the [mRo X2.1](mRo-X2.1.md), mRobotics is the new 
+No longer in production. Successor is the [mRo X2.1](./mRo-X2.1.html), mRobotics is the new 
 Distributor for the AUAV Products since August 2017.
 
 ## Key Links

--- a/en/flight_controller/auav_x2.md
+++ b/en/flight_controller/auav_x2.md
@@ -43,7 +43,7 @@ The [AUAV](http://www.auav.com/) *AUAV-X2 autopilot* is based on the [Pixhawk-pr
 
 ## Availability
 
-No longer in production. Successor is the [mRo X2.1](./mRo-X2.1.html), mRobotics is the new 
+No longer in production. Successor is the [mRo X2.1](mro_x2.1.md), mRobotics is the new 
 Distributor for the AUAV Products since August 2017.
 
 ## Key Links


### PR DESCRIPTION
Link is not working. Most probably due to Lower-/Uppercase fault.