### PR TITLE
Import preflight checks from Devguide

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -49,6 +49,7 @@
 * [Flying](flying/README.md)
   * [First Flight Guidelines](flying/first_flight_guidelines.md)
   * [LED Meanings](flying/led_meanings.md)
+  * [Preflight Checks (Internal)](flying/pre_flight_checks.md)
   * [Flying 101](flying/basic_flying.md)
     * [Landing \(Fixed Wing\)](flying/fixed_wing_landing.md)
   * [Flight Modes](flight_modes/README.md)

--- a/en/flying/led_meanings.md
+++ b/en/flying/led_meanings.md
@@ -1,15 +1,16 @@
 # LED Meanings (Pixhawk Series)
 
-[Pixhawk-series flight controllers](../flight_controller/pixhawk_series.md) have an RGB LED to indicate the current status of the vehicle. The diagram below shows the relationship between LED and vehicle status.
+[Pixhawk-series flight controllers](../flight_controller/pixhawk_series.md) have an RGB LED to indicate the current status of the vehicle. The image below shows the relationship between LED and vehicle status.
 
-![LED meanings](../../images/led_meanings.gif)
-
-> **Note** **A valid global position estimate is required to takeoff:** 
-  The LED will only turn green (ready to execute guided mission) if PX4 is able to validate the global position. If the LED does not change from blue to green, verify that the GPS module is properly attached, Pixhawk is reading your GPS properly, and that the GPS is sending a proper GPS position.  
+> **Warning** It is possible to have a GPS lock (Green LED) and still not be able to arm the vehicle because PX4 has not yet [passed preflight checks](../flying/pre_flight_checks.md). **A valid global position estimate is required to takeoff!**
 
 <span></span>
-> **Tip** In the event of an error (blinking red), or if the vehicle can't achieve GPS lock, check for more detailed status information in *QGroundControl*.
-> Useful information includes both calibration status, and any error messages from the [Preflight Checks (Internal)](../flying/pre_flight_checks.md) messages.
+> **Tip** In the event of an error (blinking red), or if the vehicle can't achieve GPS lock (change from blue to green), 
+  check for more detailed status information in *QGroundControl* including calibration status, 
+  and errors messages reported by the [Preflight Checks (Internal)](../flying/pre_flight_checks.md). 
+  Also check that the GPS module is properly attached, Pixhawk is reading your GPS properly, and that the GPS is sending a proper GPS position.
+
+![LED meanings](../../images/led_meanings.gif)
 
 
 * **[Solid Blue] Armed, No GPS Lock:** Indicates vehicle has been armed and has no position lock from a GPS unit.
@@ -26,7 +27,7 @@ As always, exercise caution when arming, as large propellers can be dangerous at
 In this mode, vehicle can perform guided missions.
 
 * **[Pulsing Green] Disarmed, GPS Lock:** Similar to above, but your vehicle is disarmed.
-This means you will not be able to control motors, but all other subsystems including GPS position lock are working.
+  This means you will not be able to control motors, but all other subsystems including GPS position lock are working.
 
 * **[Solid Purple] Failsafe Mode:** This mode will activate whenever vehicle encounters an issue during flight,
 such as losing manual control, a critically low battery, or an internal error.

--- a/en/flying/led_meanings.md
+++ b/en/flying/led_meanings.md
@@ -4,8 +4,13 @@
 
 ![LED meanings](../../images/led_meanings.gif)
 
-> **Note** **GPS Lock is required to takeoff: ** 
-  The LED will only turn green (ready to execute guided mission) if PX4 is able to validate the global position. If the LED does not change from blue to green, verify that the GPS module is properly attached, Pixhawk is reading your GPS properly, and that the GPS is sending a proper GPS position.
+> **Note** **A valid global position estimate is required to takeoff:** 
+  The LED will only turn green (ready to execute guided mission) if PX4 is able to validate the global position. If the LED does not change from blue to green, verify that the GPS module is properly attached, Pixhawk is reading your GPS properly, and that the GPS is sending a proper GPS position.  
+
+<span></span>
+> **Tip** In the event of an error (blinking red), or if the vehicle can't achieve GPS lock, check for more detailed status information in *QGroundControl*.
+> Useful information includes both calibration status, and any error messages from the [Preflight Checks (Internal)](../flying/pre_flight_checks.md) messages.
+
 
 * **[Solid Blue] Armed, No GPS Lock:** Indicates vehicle has been armed and has no position lock from a GPS unit.
 When vehicle is armed, PX4 will unlock control of the motors, allowing you to fly your drone.

--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -1,10 +1,12 @@
-# Preflight Sensor and EKF Checks
+# Preflight Sensor/Estimator Checks
 
-PX4 performs a number of preflight sensor quality and EKF checks to determine if there is a good enough position estimate to arm/fly. These checks are controlled by the [COM\_ARM\_](../advanced_config/parameter_reference.md#commander) parameters.
+PX4 performs a number of preflight sensor quality and estimator checks to determine if there is a good enough position estimate to arm and fly the vehicle (these checks are controlled by the [COM\_ARM\_](../advanced_config/parameter_reference.md#commander) parameters). Any preflight errors are reported in *QGroundControl* as `PREFLIGHT FAIL` messages. 
+
+The sections below list the errors, their likely causes and solutions, and any parameters that affect how the preflight checks are run. 
 
 ## EKF Preflight Checks/Errors
 
-The following errors (with associated checks and parameters) are reported by the EKF (and propagate to *QGroundControl*):
+The following errors (with associated checks and parameters) are reported by the [EKF](https://dev.px4.io/en/tutorials/tuning_the_ecl_ekf.html) (and propagate to *QGroundControl*):
 
 `PREFLIGHT FAIL: EKF HGT ERROR`:
 * This error is produced when the IMU and height measurement data are inconsistent.

--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -1,0 +1,71 @@
+# Preflight Sensor and EKF Checks
+
+PX4 performs a number of preflight sensor quality and EKF checks to determine if there is a good enough position estimate to arm/fly. These checks are controlled by the [COM\_ARM\_](../advanced_config/parameter_reference.md#commander) parameters.
+
+## EKF Preflight Checks/Errors
+
+The following errors (with associated checks and parameters) are reported by the EKF (and propagate to *QGroundControl*):
+
+`PREFLIGHT FAIL: EKF HGT ERROR`:
+* This error is produced when the IMU and height measurement data are inconsistent.
+* Perform an accel and gyro calibration and restart the vehicle. If the error persists, check the height sensor data for problems.
+* The check is controlled by the [COM_ARM_EKF_HGT](../advanced_config/parameter_reference.md#COM_ARM_EKF_HGT) parameter.
+
+`PREFLIGHT FAIL: EKF VEL ERROR`:
+* This error is produced when the IMU and GPS velocity measurement data are inconsistent. 
+* Check the GPS velocity data for un-realistic data jumps. If GPS quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+* The check is controlled by the [COM_ARM_EKF_VEL](../advanced_config/parameter_reference.md#COM_ARM_EKF_VEL) parameter.
+  
+`PREFLIGHT FAIL: EKF HORIZ POS ERROR`:
+* This error is produced when the IMU and position measurement data (either GPS or external vision) are inconsistent. 
+* Check the position sensor data for un-realistic data jumps. If data quality looks OK, perform an accel and gyro calibration and restart the vehicle.
+* The check is controlled by the [COM_ARM_EKF_POS](../advanced_config/parameter_reference.md#COM_ARM_EKF_POS) parameter.
+  
+`PREFLIGHT FAIL: EKF YAW ERROR`:
+* This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
+* Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
+* The check is controlled by the [COM_ARM_EKF_POS](../advanced_config/parameter_reference.md#COM_ARM_EKF_POS) parameter
+
+`PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS`:
+* This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
+* The check is controlled by the [COM_ARM_EKF_AB](../advanced_config/parameter_reference.md#COM_ARM_EKF_AB) parameter.
+  
+`PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS`:
+* This error is produced when the IMU gyro bias estimated by the EKF is excessive.
+* The check is controlled by the [COM_ARM_EKF_GB](../advanced_config/parameter_reference.md#COM_ARM_EKF_GB) parameter.
+
+`PREFLIGHT FAIL: ACCEL SENSORS INCONSISTENT - CHECK CALIBRATION`:
+* This error message is produced when the acceleration measurements from different IMU units are inconsistent.
+* This check only applies to boards with more than one IMU.
+* The check is controlled by the [COM_ARM_IMU_ACC](../advanced_config/parameter_reference.md#COM_ARM_IMU_ACC) parameter.
+
+`PREFLIGHT FAIL: GYRO SENSORS INCONSISTENT - CHECK CALIBRATION`:
+* This error message is produced when the angular rate measurements from different IMU units are inconsistent.
+* This check only applies to boards with more than one IMU.
+* The check is controlled by the [COM_ARM_IMU_GYR](../advanced_config/parameter_reference.md#COM_ARM_IMU_GYR) parameter.
+
+`PREFLIGHT FAIL: EKF INTERNAL CHECKS`:
+* This error message is generated if the innovation magnitudes of either the horizontal GPS velocity, magnetic yaw, vertical GPS velocity or vertical position sensor (Baro by default but could be range finder or GPS if non-standard parameters are being used) are excessive. Innovations are the difference between the value predicted by the inertial navigation calculation and measured by the sensor.
+* Users should check the innovation levels in the log file to determine the cause. These can be found under the `ekf2_innovations` message. 
+  Common problems/solutions include:
+  * IMU drift on warmup. May be resolved by restarting the autopilot. May require an IMU accel and gyro calibration.
+  * Adjacent magnetic interference combined with vehicle movement. Resolve my moving vehicle and waiting or re-powering.
+  * Bad magnetometer calibration combined with vehicle movement. Resolve by recalibrating.
+  * Initial shock or rapid movement on startup that caused a bad inertial nav solution. Resolve by restarting the vehicle and minimising movement for the first 5 seconds.
+
+
+## Other Parameters
+
+The following parameters also affect preflight checks.
+
+### COM_ARM_WO_GPS
+
+The [COM_ARM_WO_GPS](../advanced_config/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether or not arming is allowed without a global position estimate. 
+- `1` (default): Arming *is* allowed without a position estimate for flight modes that do not require position information (only).
+- `0`: Arming is allowed only if EKF is providing a global position estimate and EFK GPS quality checks are passing
+
+
+### COM_ARM_EKF_YAW
+
+The [COM_ARM_EKF_YAW](../advanced_config/parameter_reference.md#COM_ARM_EKF_YAW) parameter determines the maximum difference (in radians) between the navigation yaw angle and magnetic yaw angle (magnetometer or external vision) allowed before preflight checks fail. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences. It can fail if the yaw gyro has a large offset or if the vehicle is moved or rotated in the presence of a bad magnetic interference or magnetometer calibration.
+

--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -1,6 +1,8 @@
 # Preflight Sensor/Estimator Checks
 
-PX4 performs a number of preflight sensor quality and estimator checks to determine if there is a good enough position estimate to arm and fly the vehicle (these checks are controlled by the [COM\_ARM\_](../advanced_config/parameter_reference.md#commander) parameters). Any preflight errors are reported in *QGroundControl* as `PREFLIGHT FAIL` messages. 
+PX4 performs a number of preflight sensor quality and estimator checks to determine if there is a good enough position estimate to arm and fly the vehicle (these checks are controlled by the [COM\_ARM\_](../advanced_config/parameter_reference.md#commander) parameters). 
+
+> **Tip** Any preflight errors are reported in *QGroundControl* as `PREFLIGHT FAIL` messages. The `estimator_status.gps_check_fail_flags` message [in the logs](../flying/flight_reporting.md) also shows which GPS quality checks are failing.
 
 The sections below list the errors, their likely causes and solutions, and any parameters that affect how the preflight checks are run. 
 


### PR DESCRIPTION
This imports the preflight checks from devguide, makes them a little bit more "end user facing" (ie less developer focused) and cross links to other relevant docs. 

After this is merged, we need to delete the version in Devguide.