### PR TITLE
Clarify what body frame is

### DIFF
--- a/en/config/flight_controller_orientation.md
+++ b/en/config/flight_controller_orientation.md
@@ -4,7 +4,7 @@ By default the flight controller (and external compass(es), if present) should b
 
 ## Calculating Orientation
 
-YAW, PITCH and/or ROLL offsets are calculated relative to the default forward-facing-upright orientation (clock-wise rotation around the Z, Y and X axis, respectively). The default orientation is referred to as `ROTATION_NONE`.
+YAW, PITCH and/or ROLL offsets are calculated relative to the forward-facing-upright orientation (clock-wise rotation around the Z, Y and X axis, respectively). This frame is referred to as the *body frame* and the default orientation as `ROTATION_NONE`.
 
 <img src="../../images/fc_orientation_1.png" style="width: 600px;"/>
 


### PR DESCRIPTION
This doc is the place where body frame is effectively defined, but that term was not used. This change at least means the page will show up when the term is searched. 

@bkueng I have been avoiding creating a glossary but this seems like it might be a good idea? 

FYI If so I will avoid the gitbook glossary infrastructure as this automatically cross links glossary terms (slows build time to a crawl).