### PR TITLE
Clarify compass support

### DIFF
--- a/en/config/compass.md
+++ b/en/config/compass.md
@@ -1,10 +1,11 @@
 # Compass Calibration
 
-*QGroundControl* will guide you to position the vehicle in a number of set orientations and rotate the vehicle about the specified axis. 
+The compass calibration process configures all connected internal and external [magnetometers](../gps_compass/README.md).
+*QGroundControl* will guide you to position the vehicle in a number of set orientations and rotate the vehicle about the specified axis.
+
+> **Note** If you are using an external magnetometer/compass (e.g. a compass integrated into a GPS module) make sure you mount the external compass on your vehicle properly and connect it to the autopilot hardware. Instructions for connecting your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware. Once connected, QGroundControl will automatically detect the external magnetometer. 
 
 ## Performing the Calibration 
-
-> **Note** If you are using an external magnetometer/compass for example a compass integrated into a GPS module, make sure you mount the external compass on your vehicle properly and connect it to the autopilot hardware. Instructions for connecting your GPS+compass can be found in [Basic Assembly](../assembly/README.md) for your specific autopilot hardware. Once connected, QGroundControl will automatically detect the external mag.  
 
 The calibration steps are:
 

--- a/en/getting_started/sensor_selection.md
+++ b/en/getting_started/sensor_selection.md
@@ -14,7 +14,11 @@ Below we describe some of the sensors. At the end there are links to information
 PX4 supports a number of global navigation satellite system (GNSS) receivers and compasses (magnetometers). 
 It also supports [Real Time Kinematic (RTK) GPS Receivers](../gps_compass/rtk_gps.md), which extend GPS systems to centimetre-level precision.
 
-> **Tip** The Pixhawk internal compass is close to other electronics, and may be susceptible to electromagnetic noise. An external compass/GPS mounted on a pedestal or wing (for fixed-wing) away from the rest of the system is recommended.
+> **Tip** [Pixhawk-series](../flight_controller/pixhawk_series.md) controllers include an *internal* compass. 
+  This *may* be useful on larger vehicles (e.g. VTOL) where it is possible to reduce electromagnetic interference by mounting the Pixhawk a long way from power supply lines.
+  On small vehicles an external compass is almost always required.
+
+We recommend the use of an external "combined" compass/GPS module mounted as far away from the motor/ESC power supply lines as possible - typically on a pedestal or wing (for fixed-wing).
 
 Common GPS/compass hardware options are listed in: [GPS/Compass](../gps_compass/README.md).
 

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -1,13 +1,19 @@
 # GPS & Compass
 
-PX4 supports global navigation satellite systems (GNSS) (including GPS, GLONASS, Galileo, BeiDou, QZSS and SBAS) using receivers that communicate via the UBlox, MTK or Ashtech protocols, or via UAVCAN. It also supports [Real Time Kinematic (RTK) GPS Receivers](../gps_compass/rtk_gps.md), which extends GPS systems to centimetre-level precision.
+PX4 supports global navigation satellite systems (GNSS) (including GPS, GLONASS, Galileo, BeiDou, QZSS and SBAS) using receivers that communicate via the UBlox, MTK or Ashtech protocols, or via UAVCAN. It also supports [Real Time Kinematic (RTK) GPS Receivers](../gps_compass/rtk_gps.md), which extend GPS systems to centimetre-level precision.
 
 PX4 can be used with the following compass parts (magnetometers): Bosch BMM 150 MEMS (via I2C bus), HMC5883 / HMC5983 (I2C or SPI), IST8310 (I2C) and LIS3MDL (I2C or SPI).
 
-> **Tip** When using Pixhawk-series flight controllers we recommend using a *combined GPS + Compass* (the Pixhawk internal compass is close to other electronics, and may be susceptible to electromagnetic noise).
+Up to 4 internal or external magnetometers can be connected, though only one will actually be used as a heading source.
+The system automatically chooses the best available compass based on their internal priority (external magnetometers have a higher priority).
+If the primary compass fails in-flight, it will failover to the next one.
+If it fails before flight, arming will be denied.
 
 ![GPS + Compass](../../images/gps_compass.jpg)
 
+> **Tip** When using [Pixhawk-series](../flight_controller/pixhawk_series.md) flight controllers, we recommend using a *combined GPS + Compass* mounted as far away from the motor/ESC power supply lines as possible - typically on a pedestal or wing (for fixed-wing). 
+  The internal compass *may* be useful on larger vehicles (e.g. VTOL) where it is possible to reduce electromagnetic interference by mounting the Pixhawk a long way from power supply lines.
+  On small vehicles an external compass is almost always required.
 
 ## Combined GPS/Compass Options
 
@@ -24,17 +30,34 @@ Some popular GPS/compass options include:
 
 Instructions for connecting the GPS and compass are usually provided by the manufacturer (at least for more common [Autopilot Hardware](../flight_controller/README.md)). 
 
-> **Note** [Pixhawk Series](../flight_controller/pixhawk_series.md) controllers usually have a clearly labeled port for connecting the GPS, and the compass is connected to either the I2C or SPI port/bus (depending on the device). The [Zubax GNSS 2](https://zubax.com/products/gnss_2) can also be connected via [UAVCAN](https://dev.px4.io/en/uavcan/).
+> **Note** [Pixhawk Series](../flight_controller/pixhawk_series.md) controllers usually have a clearly labeled port for connecting the GPS, and the compass is connected to either the I2C or SPI port/bus (depending on the device). 
+  The [Zubax GNSS 2](https://zubax.com/products/gnss_2) can also be connected via [UAVCAN](https://dev.px4.io/en/uavcan/).
 
 <span></span>
-> **Tip** Pay attention to pinout when connecting the GPS module. While these are all software-compatible, there are several different pin orderings.
-
-GPS configuration is handled transparently for the user (provided the module GPS connector is connected correctly). Compass setup is covered in: [Compass Configuration](../config/compass.md).
+> **Tip** Pay attention to pinout when connecting the GPS module. 
+  While these are all software-compatible, there are several different pin orderings.
 
 
 ## RTK-GPS Devices
 
 Information about supported devices and setup/configuration can be found in the sidebar under: [RTK GPS](../gps_compass/rtk_gps.md).
+
+
+## Configuration
+
+### GPS
+
+GPS configuration is handled transparently for the user (provided the module GPS connector is connected correctly).
+
+### Compass
+
+Compass calibration is covered in: [Compass Configuration](../config/compass.md).
+The process is straightforward and will calibrate all connected magnetometers.
+
+Additional configuration can be [performed](../advanced_config/parameters.md) using the [CAL\_MAGx\_](../advanced_config/parameter_reference.md#CAL_MAG0_EN) parameters (where `x=0-3`).
+Generally you will not need to *modify* these as compasses are autodetected, prioritised and are all calibrated at the same time
+(a possible exception is [CAL\_MAGx\_EN](../advanced_config/parameter_reference.md#CAL_MAG0_EN) which might be used to disable an internal compass).
+You may however wish to read them, as they will let you know which magnetometers are internal or external ([CAL\_MAGx\_EN](../advanced_config/parameter_reference.md#CAL_MAG0_EN)) and which is being uses as the main heading source ([CAL_MAG_PRIME](../advanced_config/parameter_reference.md#CAL_MAG_PRIME)).
 
 
 ## Developer Information


### PR DESCRIPTION
This does two things:
1. Makes it clear when the internal compass on pixhawk might be useful
2. Explains how multiple compasses are supported and configured (ie failover etc).