### PR TITLE
RTK and dual GPS usage

### DIFF
--- a/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/en/advanced_config/tuning_the_ecl_ekf.md
@@ -79,19 +79,33 @@ GPS measurements will be used for position and velocity if the following conditi
 * GPS height can be used directly by the EKF via setting of the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter.
 
 #### Yaw Measurements
-Some GPS receivers such as the [Trimble MB-Two RTK GPS receiver](https://www.trimble.com/Precision-GNSS/MB-Two-Board.aspx) can be use to provide a heading measurement that replaces the use of magnetomer data. This can be a significant advantage when operating in an environment where large magnetic anomalies are present or at latitudes here the earths magnetic field has a high inclination. Use of GPS yaw measurements is enabled by setting bit position 7 to 1 (adding 128) in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter.
+
+Some GPS receivers such as the [Trimble MB-Two RTK GPS receiver](https://www.trimble.com/Precision-GNSS/MB-Two-Board.aspx) can be used to provide a heading measurement that replaces the use of magnetometer data. 
+This can be a significant advantage when operating in an environment where large magnetic anomalies are present, or at latitudes here the earth's magnetic field has a high inclination. 
+Use of GPS yaw measurements is enabled by setting bit position 7 to 1 (adding 128) in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter.
 
 #### Dual Receivers
-Data from GPS receivers can be blended using an algorithm that weights data based on reported accuracy and also provides automatic failover if data froma  receiver is lost. This is controlled by the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter. This works best if both receivers output at the same data rate and use the same accuracy, however it is also enables a standard GPS to be used as a backup to a more accurate RTK receiver. 
 
-The [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set by default to disable blending and always use the first receiver, so it will have to be set to select which receiver accuracvy metrics are used to decide how much each receiver output contributes to the blended solutiohn. Where different receiver models are used, it is important that the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set to a value that uses accuracy metrics that are supported by both receivers. For example do not set bit position 0 to true unless the driver for both receivers publish values in the s_variance_m_s field of the vehicle_gps_position message that are comparable. This can be difficult with receivers from different manufacturers due to the different way that accuracy is defined, eg CEP vs 1-sigma, etc. 
+Data from GPS receivers can be blended using an algorithm that weights data based on reported accuracy (this works best if both receivers output data at the same rate and use the same accuracy).
+The mechanism also provides automatic failover if data from a receiver is lost (it allows, for example, a standard GPS to be used as a backup to a more accurate RTK receiver). 
+This is controlled by the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter. 
+
+The [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set by default to disable blending and always use the first receiver, so it will have to be set to select which receiver accuracy metrics are used to decide how much each receiver output contributes to the blended solution. 
+Where different receiver models are used, it is important that the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set to a value that uses accuracy metrics that are supported by both receivers. 
+For example do not set bit position 0 to `true` unless the drivers for both receivers publish values in the `s_variance_m_s` field of the `vehicle_gps_position` message that are comparable. 
+This can be difficult with receivers from different manufacturers due to the different way that accuracy is defined, e.g. CEP vs 1-sigma, etc.
 
 The following items should be checked during setup:
 
-* Verfiy that data for the second receiver is present. This will be logged as vehicle_gps_position_1 and can also be checked when connected via  nsh concole using the 'listener' command.
-* Check the 's_variance_m_s', 'eph' and 'epv' data from each receiver and decide which accuracy metrics can be used. If both receivers output sensible 's_variance_m_s' and 'eph' data and GPS vertical positon is not being used directly for navigation, then setting [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 3 is recommmeded. Where only 'eph' data is available and both receivers do not output 's_variance_m_s' data, set [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 2. Bit position 2 would only be set if the GPS had been selected as a primary height source with the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter and both receivers output sensible 'epv' data.
-* The output from the blended receiver data is logged as vehicle_gps_position_2 and should be checked.
-* Where receivers output at different rates, the blended output will be at the rate of slower receiver. Where possible receivers should be configured to output at the same rate.
+* Verify that data for the second receiver is present. 
+  This will be logged as `vehicle_gps_position_1` and can also be checked when connected via *nsh console* using the `listener` command.
+* Check the `s_variance_m_s`, `eph` and `epv` data from each receiver and decide which accuracy metrics can be used. 
+  If both receivers output sensible `s_variance_m_s` and `eph` data, and GPS vertical position is not being used directly for navigation, then setting [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 3 is recommmeded. 
+  Where only `eph` data is available and both receivers do not output `s_variance_m_s` data, set [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 2. 
+  Bit position 2 would only be set if the GPS had been selected as a primary height source with the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter and both receivers output sensible `epv` data.
+* The output from the blended receiver data is logged as `vehicle_gps_position_` and should be checked.
+* Where receivers output at different rates, the blended output will be at the rate of slower receiver. 
+  Where possible receivers should be configured to output at the same rate.
 
 ### Range Finder
 

--- a/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/en/advanced_config/tuning_the_ecl_ekf.md
@@ -70,12 +70,28 @@ When tilt and yaw alignment is complete, the EKF can then transition to other mo
 
 ### GPS
 
+#### Position and Velocity Measurements
 GPS measurements will be used for position and velocity if the following conditions are met:
 
 * GPS use is enabled via setting of the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter.
 * GPS quality checks have passed. 
   These checks are controlled by the [EKF2_GPS_CHECK](../advanced_config/parameter_reference.md#EKF2_GPS_CHECK) and `EKF2_REQ_*` parameters. 
 * GPS height can be used directly by the EKF via setting of the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter.
+
+#### Yaw Measurements
+Some GPS receivers such as the [Trimble MB-Two RTK GPS receiver](https://www.trimble.com/Precision-GNSS/MB-Two-Board.aspx) can be use to provide a heading measurement that replaces the use of magnetomer data. This can be a significant advantage when operating in an environment where large magnetic anomalies are present or at latitudes here the earths magnetic field has a high inclination. Use of GPS yaw measurements is enabled by setting bit position 7 to 1 (adding 128) in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter.
+
+#### Dual Receivers
+Data from GPS receivers can be blended using an algorithm that weights data based on reported accuracy and also provides automatic failover if data froma  receiver is lost. This is controlled by the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter. This works best if both receivers output at the same data rate and use the same accuracy, however it is also enables a standard GPS to be used as a backup to a more accurate RTK receiver. 
+
+The [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set by default to disable blending and always use the first receiver, so it will have to be set to select which receiver accuracvy metrics are used to decide how much each receiver output contributes to the blended solutiohn. Where different receiver models are used, it is important that the [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) parameter is set to a value that uses accuracy metrics that are supported by both receivers. For example do not set bit position 0 to true unless the driver for both receivers publish values in the s_variance_m_s field of the vehicle_gps_position message that are comparable. This can be difficult with receivers from different manufacturers due to the different way that accuracy is defined, eg CEP vs 1-sigma, etc. 
+
+The following items should be checked during setup:
+
+* Verfiy that data for the second receiver is present. This will be logged as vehicle_gps_position_1 and can also be checked when connected via  nsh concole using the 'listener' command.
+* Check the 's_variance_m_s', 'eph' and 'epv' data from each receiver and decide which accuracy metrics can be used. If both receivers output sensible 's_variance_m_s' and 'eph' data and GPS vertical positon is not being used directly for navigation, then setting [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 3 is recommmeded. Where only 'eph' data is available and both receivers do not output 's_variance_m_s' data, set [EKF2_GPS_MASK](../advanced_config/parameter_reference.md#EKF2_GPS_MASK) to 2. Bit position 2 would only be set if the GPS had been selected as a primary height source with the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter and both receivers output sensible 'epv' data.
+* The output from the blended receiver data is logged as vehicle_gps_position_2 and should be checked.
+* Where receivers output at different rates, the blended output will be at the rate of slower receiver. Where possible receivers should be configured to output at the same rate.
 
 ### Range Finder
 

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -103,3 +103,10 @@ For example, you can decrease [EKF2_GPS_V_NOISE](../advanced_config/parameter_re
 
 The airframe build topic [DJI Flamewheel 450 with distance sensor and RTK GPS](https://dev.px4.io/en/airframes_multicopter/dji_flamewheel_450.html) describes an airframe setup with the Here+ RTK GPS and a Pixhawk 3 Pro.
 
+## Use of RTK GPS for yaw
+
+If you are using a GPS unit that uses multiple antennas to output a yaw angle, this can be used instead of the magnetic compass. To enable this, set bit position 7 in [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) to 1 (add 128 to the parameter value).
+
+## Dual Receivers
+
+A second receiver, either RTK or non RTK can be used as a backup. See the [EKF2 GPS Configuration](../advanced_config/tuning_the_ecl_ekf.md#GPS) section.

--- a/en/gps_compass/rtk_gps.md
+++ b/en/gps_compass/rtk_gps.md
@@ -93,6 +93,17 @@ To ensure MAVLink2 is used:
 You may also need to tune some parameters as the default parameters are tuned assuming a GPS accuracy in the order of meters, not centimeters. 
 For example, you can decrease [EKF2_GPS_V_NOISE](../advanced_config/parameter_reference.md#EKF2_GPS_V_NOISE) and [EKF2_GPS_P_NOISE](../advanced_config/parameter_reference.md#EKF2_GPS_P_NOISE) to 0.2.
 
+
+### Use RTK GPS for Yaw
+
+Some RTK GPS units (i.e. with multiple antennas) can output a yaw angle, which can be used instead of the heading from the magnetic compass.
+To enable this, set bit position 7 in [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) to 1 (add 128 to the parameter value).
+
+### Dual Receivers
+
+A second GPS receiver can be used as a backup (either RTK or non RTK). 
+See the [EKF2 GPS Configuration](../advanced_config/tuning_the_ecl_ekf.md#GPS) section.
+
 <!-- 
 - Video demonstration would be nice.
 - something that shows positioning of base, connection of RTK rover, survey in process. Some sort of short precision survey. 
@@ -103,10 +114,3 @@ For example, you can decrease [EKF2_GPS_V_NOISE](../advanced_config/parameter_re
 
 The airframe build topic [DJI Flamewheel 450 with distance sensor and RTK GPS](https://dev.px4.io/en/airframes_multicopter/dji_flamewheel_450.html) describes an airframe setup with the Here+ RTK GPS and a Pixhawk 3 Pro.
 
-## Use of RTK GPS for yaw
-
-If you are using a GPS unit that uses multiple antennas to output a yaw angle, this can be used instead of the magnetic compass. To enable this, set bit position 7 in [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) to 1 (add 128 to the parameter value).
-
-## Dual Receivers
-
-A second receiver, either RTK or non RTK can be used as a backup. See the [EKF2 GPS Configuration](../advanced_config/tuning_the_ecl_ekf.md#GPS) section.


### PR DESCRIPTION
Adds information on how to configure the EKF to use RTK GPS for yaw and use of dual GPS.