### PR TITLE
BootloaderUpdate: Make generic

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -101,7 +101,7 @@
     * [VTOL Weather Vane](config_vtol/vtol_weathervane.md)
   * [ESC Calibration](advanced_config/esc_calibration.md)
   * [ECL/EKF Overview & Tuning](advanced_config/tuning_the_ecl_ekf.md)
-  * [Bootloader Update (FMUv2)](advanced_config/bootloader_update.md)
+  * [Bootloader Update](advanced_config/bootloader_update.md)
   * [Land Detector Configuration](advanced_config/land_detector.md)
   * [Sensor Thermal Compensation](advanced_config/sensor_thermal_calibration.md)
   * [Advanced Controller Orientation](advanced_config/advanced_flight_controller_orientation_leveling.md)

--- a/en/advanced_config/bootloader_update.md
+++ b/en/advanced_config/bootloader_update.md
@@ -13,6 +13,8 @@ This topic explains several methods for updating the Pixhawk bootloader.
 The easiest approach is to first use *QGroundControl* to install firmware with the desired/latest bootloader. 
 You can then initiate bootloader update on next restart by setting the parameter: [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
 
+> **Note** This approach can only be used if [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE) is present in firmware (currently just FMUv2 and some custom firmware).
+
 The steps are:
 
 1. Insert an SD card (enables boot logging to debug any problems).

--- a/en/advanced_config/bootloader_update.md
+++ b/en/advanced_config/bootloader_update.md
@@ -1,34 +1,86 @@
 # Bootloader Update
 
-Early [Pixhawk-series](../flight_controller/pixhawk_series.md#fmu-versions) flight controllers based on FMUv2 had a hardware issue ([Silicon Errata](../flight_controller/silicon_errata.md#fmuv2--pixhawk-silicon-errata)) that restricted them to using 1MB of flash memory. 
-The problem was fixed on newer hardware, so it can now (in theory) install FMUv3 Firmware and access all 2MB available memory.
+The [PX4 bootloader](https://github.com/PX4/Bootloader) is used to load firmware for Pixhawk boards (PX4FMU, PX4IO) and [PX4FLOW](../sensor/px4flow.md).
 
-Unfortunately some boards come from the factory with an old bootloader that is unable to detect whether or not the hardware issue is present. 
-As a result, the memory-restricted FMUv2 Firmware must still be used.
+This topic explains several methods for updating the Pixhawk bootloader.
 
-This topic explains how you can update the bootloader to the latest version so that you can use FMUv3 Firmware on compatible boards.
+> **Note** Hardware usually comes with an appropriate bootloader version pre-installed.
+  A case where you may need to update is newer Pixhawk boards that install FMUv2 firmware: [Firmware > FMUv2 Bootloader Update](../config/firmware.md#bootloader).
 
 
-### Main Steps
+## QGroundControl Bootloader Update {#qgc_bootloader_update}
 
-You can initiate bootloader update on next restart by setting the parameter: [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
+The easiest approach is to first use *QGroundControl* to install firmware with the desired/latest bootloader. 
+You can then initiate bootloader update on next restart by setting the parameter: [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
 
-To update the bootloader:
+The steps are:
 
-1. Insert an SD card (enables boot logging to debug any problems.)
-1. [Update the Firmware](../config/firmware.md) to PX4 *master* version (when updating the firmware, check **Advanced settings** and then select **Developer Build (master)** from the dropdown list).
-   *QGroundControl* will automatically detect that the hardware supports FMUv2 and install the appropriate Firmware.
+1. Insert an SD card (enables boot logging to debug any problems).
+1. [Update the Firmware](../config/firmware.md#custom) with an image containing the new/desired bootloader.
    
+   > **Tip** The updated bootloader might be supplied in custom firmware (i.e. from the dev team), or it or may be included in the latest master.
+
    ![FMUv2 update](../../assets/qgc/setup/firmware/bootloader_update.jpg)
-   
-   Wait for the vehicle to reboot.
+1. Wait for the vehicle to reboot.
 1. [Find and enable](../advanced_config/parameters.md#parameter-configuration) the parameter [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
-1. Reboot (disconnect/reconnect the board). 
+1. Reboot (disconnect/reconnect the board).
    The bootloader update will only take a few seconds.
-1. Then [Update the Firmware](../config/firmware.md) again. 
-   This time *QGroundControl* should autodetect the hardware as FMUv3 and update the Firmware appropriately.
+   
+Generally at this point you may then want to [update the firmware](../config/firmware.md) again using the correct/newly installed bootloader.
 
-   ![FMUv3 update](../../assets/qgc/setup/firmware/bootloader_fmu_v3_update.jpg)
 
-   > **Note** If the hardware has the *Silicon Errata* it will still be detected as FMUv2 and you will see that FMUv2 was re-installed (in console). 
-     In this case you will not be able to install FMUv3 hardware.
+### Dronecode Probe Bootloader Update {#dronecode_probe}
+
+The following steps explain how you can "manually" update the bootloader using the dronecode probe:
+
+1. Get a binary containing the bootloader (either from dev team or build it yourself).
+1. Connect the Dronecode probe to your PC via USB. 
+1. Go into the directory containing the binary and run the following command in the terminal:
+   ```cmd
+   arm-none-eabi-gdb px4fmuv5_bl.elf
+   ```
+1. The *gdb terminal* appears and it should display the following output:
+   ```cmd
+GNU gdb (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 8.0.50.20171128-git
+Copyright (C) 2017 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
+and "show warranty" for details.
+This GDB was configured as "--host=x86_64-linux-gnu --target=arm-none-eabi".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<http://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+<http://www.gnu.org/software/gdb/documentation/>.
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from px4fmuv5_bl.elf...done.
+   ```
+1. Find your `<dronecode-probe-id>` by running an ls command in the **/dev/serial/by-id** directory.
+1. Now connect to the Dronecode probe with the following command:
+   ```
+   tar ext /dev/serial/by-id/<dronecode-probe-id>
+   ```
+1. Power on the Pixhawk with another USB cable and connect the Dronecode probe to the FMU-DEBUG port. 
+
+   > **Note** To be able to connect the Dronecode probe to the FMU-DEBUG port, you may need to remove the case (e.g. on Pixhawk 4 you would do this using a T6 Torx screwdriver).
+
+1. Use the following command to scan for the Pixhawk’s swd and connect to it:
+   ```
+   (gdb) mon swdp_scan
+   (gdb) attach 1
+   ```
+1. Load the binary into the Pixhawk:
+   ```
+   (gdb) load
+   ```
+
+After the bootloader has updated you can [Load PX4 Firmware](../config/firmware.md) using *QGroundControl*.
+
+## Other Boards (Non-Pixhawk) {#non-pixhawk}
+
+Boards that are not part of the [Pixhawk Series](../flight_controller/pixhawk_series.md) will have their own mechanisms for bootloader update.
+
+These will be documented (where relevant) with the board:
+- [Omnibus F4 SD > PX4 Bootloader Update](../flight_controller/omnibus_f4_sd.md#upload)

--- a/en/config/firmware.md
+++ b/en/config/firmware.md
@@ -2,9 +2,16 @@
 
 *QGroundControl* **desktop** versions can be used to install PX4 firmware onto [Pixhawk-series](../getting_started/flight_controller_selection.md) flight-controller boards. 
 
-> **Caution** **Before you start installing Firmware** all USB connections to you vehicle must be *disconnected* (both direct or through a telemetry radio). The vehicle must *not be* powered by a battery.
+> **Caution** **Before you start installing Firmware** all USB connections to the vehicle must be *disconnected* (both direct or through a telemetry radio). 
+  The vehicle must *not be* powered by a battery.
 
-To install the latest firmware update:
+## Install Stable PX4
+
+Generally you should use the most recent *released* version of PX4, in order to benefit from bug fixes and get the latest and greatest features.
+ 
+> **Tip** This is the version that is installed by default.
+
+To install PX4:
 
 1. First select the **Gear** icon (*Vehicle Setup*) in the top toolbar and then **Firmware** in the sidebar. 
 
@@ -14,17 +21,9 @@ To install the latest firmware update:
 
    > **Note** Connect directly to a powered USB port on your machine (do not connect through a USB hub).
 
-1. Once the controller is connected you can choose which firmware to load (*QGroundControl* presents sensible options based on the connected hardware). 
-   
-   * Select the **PX4 Flight Stack XXX Release** option to install the latest stable version of PX4 *for your hardware* (autodetected).
-   
-     ![Install PX4 default](../../assets/qgc/setup/firmware/firmware_connected_default_px4.jpg)
-   
-   > **Tip** To install a different version of PX4, check **Advanced settings** and select the version from the dropdown list.
-   >
-   > ![Install PX4 version](../../assets/qgc/setup/firmware/qgc_choose_firmware.jpg)
-   >
-   >   * If you select **Custom firmware file** you will need to choose the custom firmware from the file system in the next step.
+1. Select the **PX4 Flight Stack X.x.x Release** option to install the latest stable version of PX4 *for your hardware* (autodetected).
+
+   ![Install PX4 default](../../assets/qgc/setup/firmware/firmware_connected_default_px4.jpg)
 
 1. Click the **OK** button to start the update.
 
@@ -34,12 +33,56 @@ To install the latest firmware update:
    ![Firmware upgrade complete](../../assets/qgc/setup/firmware/firmware_upgrade_complete.jpg)
    
    Once the firmware has completed loading, the device/vehicle will reboot and reconnect.
+   
+   > **Tip** If *QGroundControl* installs the FMUv2 target (see console during installation) and you have a newer board, you may need to [update the bootloader](#bootloader) in order to access all the memory on your flight controller.
 
 Next you will need to specify the [vehicle airframe](../config/airframe.md) (and then sensors, radio, etc.)
 
 
+## Installing PX4 Master, Beta or Custom Firmware {#custom}
 
-> **Tip** If *QGroundControl* installs the FMUv2 target (see console during installation) and you have a newer board, you may need to update the bootloader in order to access all the memory on your flight controller. See [Bootloader Update](../advanced_config/bootloader_update.md) for more information.
+To install a different version of PX4:
+1. Connect the vehicle as above, and select **PX4 Flight Stack vX.x.x Stable Release**
+   ![Install PX4 version](../../assets/qgc/setup/firmware/qgc_choose_firmware.jpg)
+1. Check **Advanced settings** and select the version from the dropdown list:
+   - **Standard Version (stable):** The default version (i.e. no need to use advanced settings to install this!)
+   - **Beta Testing (beta):** A beta/candidate release.
+     Only available when a new release is being prepared.
+   - **Developer Build (master):** The latest build of PX4/Firmware.
+   - **Custom Firmware file...:** A custom firmware file (e.g. that you have built locally).
+     If you select this you will have to choose the custom firmware from the file system in the next step.
+
+Firmware update then continues as before.
+
+
+## FMUv2 Bootloader Update {#bootloader}
+
+If *QGroundControl* installs the FMUv2 target (see console during installation), and you have a newer board, you may need to update the bootloader in order to access all the memory on your flight controller.
+
+> **Note** Early FMUv2 [Pixhawk-series](../flight_controller/pixhawk_series.md#fmu-versions) flight controllers had a [hardware issue](../flight_controller/silicon_errata.md#fmuv2--pixhawk-silicon-errata) that restricted them to using 1MB of flash memory.
+  The problem is fixed on newer boards, but you may need to update the factory-provided bootloader in order to install FMUv3 Firmware and access all 2MB available memory.
+
+To update the bootloader:
+
+1. Insert an SD card (enables boot logging to debug any problems).
+1. [Update the Firmware](../config/firmware.md) to PX4 *master* version (when updating the firmware, check **Advanced settings** and then select **Developer Build (master)** from the dropdown list).
+   *QGroundControl* will automatically detect that the hardware supports FMUv2 and install the appropriate Firmware.
+   
+   ![FMUv2 update](../../assets/qgc/setup/firmware/bootloader_update.jpg)
+   
+   Wait for the vehicle to reboot.
+1. [Find and enable](../advanced_config/parameters.md#parameter-configuration) the parameter [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
+1. Reboot (disconnect/reconnect the board). 
+   The bootloader update will only take a few seconds.
+1. Then [Update the Firmware](../config/firmware.md) again. 
+   This time *QGroundControl* should autodetect the hardware as FMUv3 and update the Firmware appropriately.
+
+   ![FMUv3 update](../../assets/qgc/setup/firmware/bootloader_fmu_v3_update.jpg)
+
+   > **Note** If the hardware has the *Silicon Errata* it will still be detected as FMUv2 and you will see that FMUv2 was re-installed (in console). 
+     In this case you will not be able to install FMUv3 hardware.
+
+> **Tip** For more information see [Bootloader Update](../advanced_config/bootloader_update.md).
 
 
 ## Further Information

--- a/en/flight_controller/silicon_errata.md
+++ b/en/flight_controller/silicon_errata.md
@@ -12,7 +12,7 @@ Silicon revisions up to rev 2 (revision 3 is the first not affected) can produce
 Since USB is needed to program the device, Pixhawk revisions built with silicon revisions < rev 3 can only use up to 1MB of the 2MB flash of the microprocessor.
 
 > **Tip** The errata is fixed in later versions, but this may not be detected if you are using an older bootloader. 
-  See [Bootloader Update](../advanced_config/bootloader_update.md) for more information.
+  See [Firmware > FMUv2 Bootloader Update](../config/firmware.md#bootloader) for more information.
 
 
 ## FMUv1 / Pixhawk Silicon Errata


### PR DESCRIPTION
This makes the bootloader doc "generic", adding the option for using dronecode probe to it. 

The info on FMUv2 update is now directly included in the page on Firmware update. There is some duplication in docs from this, but I am OK with that.