### PR TITLE
Non controversial fixes to rangefinder structure

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -132,6 +132,8 @@
     * [LeddarOne Lidar](sensor/leddar_one.md)
     * [Benewake TFmini Lidar](sensor/tfmini.md)
     * [Lidar-Lite](sensor/lidar_lite.md)
+    * [TeraRanger](sensor/teraranger.md)
+    
   * [Airspeed Sensors](sensor/airspeed.md)
   * [Optical Flow](sensor/optical_flow.md)
     * [PX4FLOW](sensor/px4flow.md)

--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -2,9 +2,8 @@
 
 Distance sensors provide distance measurement that can be used for terrain following, precision hovering (e.g. for photography), warning of regulatory height limits, collision avoidance etc.
 
-The sensors can usually be connected to either a serial (PWM) or I2C port (depending on the device driver), and is enabled on the port by setting a particular parameter.
-
-This section lists the distance sensors supported by PX4 (linked to more detailed documentation), the [generic configuration](#configuration) required for all rangefinders, testing, and simulation information.
+This section lists the distance sensors supported by PX4 (linked to more detailed documentation), the [generic configuration](#configuration) required for all rangefinders, [testing](#testing), and [simulation](#simulation) information.
+More detailed setup and configuration information is provided in the topics linked below (and sidebar).
 
 <img src="../../assets/hardware/sensors/lidar_lite/lidar_lite_v3.jpg" alt="Lidar Lite V3" width="200px" /><img src="../../assets/hardware/sensors/sf11c_120_m.jpg" alt="LightWare SF11/C Lidar" width="200px" /><img src="../../assets/hardware/sensors/uLanding_lite_1.jpg" alt="Aerotenna uLanding" width="200px" />
 
@@ -18,7 +17,8 @@ It has a sensor range from (5cm - 40m) and can be connected to either PWM or I2C
 
 ### MaxBotix I2CXL-MaxSonar-EZ
 
-The MaxBotix [I2CXL-MaxSonar-EZ](https://www.maxbotix.com/product-category/i2cxl-maxsonar-ez-products) range has a number of relatively short-ranged sonar based rangefinders that are suitable for assisted takeoff/landing and collision avoidance. These can be connected using an I2C port.
+The MaxBotix [I2CXL-MaxSonar-EZ](https://www.maxbotix.com/product-category/i2cxl-maxsonar-ez-products) range has a number of relatively short-ranged sonar based rangefinders that are suitable for assisted takeoff/landing and collision avoidance. 
+These can be connected using an I2C port.
 
 The rangefinders are enabled using the parameter [SENS_EN_MB12XX](../advanced_config/parameter_reference.md#SENS_EN_MB12XX).
 
@@ -37,28 +37,22 @@ Drivers exist for both I2C and serial ports (not all devices are supported for b
 
 ### TeraRanger Rangefinders
 
-TeraRanger provide a number of lightweight distance measurement sensor based on infrared Time-of-Flight (ToF) technology. They are typically faster and have greater range than sonar, and smaller and lighter than laser-based systems. PX4 supports:
-* [TeraRanger One](http://www.teraranger.com/products/teraranger-one/) (0.2 - 14 m) (Requires an [I2C adapter](http://www.teraranger.com/product/teraranger-i2c-adapter/))
-* [TeraRanger Evo 60m](https://www.terabee.com/portfolio-item/teraranger-evo-infrared-distance-sensor/) (0.5 – 60 m)
-* TeraRanger Evo 600Hz (0.75 - 8 m)
+[TeraRanger](../sensor/teraranger.md) provide a number of lightweight distance measurement sensors based on infrared Time-of-Flight (ToF) technology. 
+They are typically faster and have greater range than sonar, and smaller and lighter than laser-based systems. 
 
-All TeraRanger sensors must be connected via the I2C bus. While TeraRanger One requires an [I2C adapter](http://www.teraranger.com/product/teraranger-i2c-adapter/) any sensor from TeraRanger Evo series can be connected directly to the autopilot. 
+PX4 supports the following models connected via the I2C bus: TeraRanger One, TeraRanger Evo 60m and TeraRanger Evo 600Hz.
 
-The sensors are enabled using the parameter [SENS_EN_TRANGER](../advanced_config/parameter_reference.md#SENS_EN_TRANGER) (you can set the type of sensor or that PX4 should auto-detect the type).
-
-> **Note** If using auto-detect for Evo sensors the minimum and maximum values for the range are set to the lowest and highest possible readings across the Evo family (currently 0.5 - 60 m). In order to use the correct max/min values the appropriate model of the Evo sensor should be set in the parameter (instead of using autodetect).
-
-<span></span>
-> **Info** The *Terranger One* is used in the [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md).
 
 ### uLanding Radar
 
-The [*Aerotenna* uLanding Radar](../sensor/ulanding_radar.md) is compact microwave rangefinder that has been optimised for use on UAVs. It has a sensing range of 45m. A particular advantages of this product are that it can operate effectively in all weather conditions and over all terrain types (including water).
+The [*Aerotenna* uLanding Radar](../sensor/ulanding_radar.md) is compact microwave rangefinder that has been optimised for use on UAVs. 
+It has a sensing range of 45m. A particular advantages of this product are that it can operate effectively in all weather conditions and over all terrain types (including water).
 
 
 ### LeddarOne
 
-[LeddarOne](../sensor/leddar_one.md) is small Lidar module with a narrow, yet diffuse beam that offers excellent overall detection range and performance, in a robust, reliable, cost-effective package. It has a sensing range from 1cm to 40m and needs to be connected to a UART/serial bus.
+[LeddarOne](../sensor/leddar_one.md) is small Lidar module with a narrow, yet diffuse beam that offers excellent overall detection range and performance, in a robust, reliable, cost-effective package.
+It has a sensing range from 1cm to 40m and needs to be connected to a UART/serial bus.
 
 
 ### TFmini
@@ -71,31 +65,47 @@ The [Benewake TFmini Lidar](../sensor/tfmini.md) is a tiny, low cost, and low po
 PX4 also supports the Bebop rangefinder.
 
 
-## Rangefinder Configuration {#configuration}
+## Configuration/Setup {#configuration}
 
-### Setup
+Rangefinders are usually connected to either a serial (PWM) or I2C port (depending on the device driver), and are enabled on the port by setting a particular parameter.
+The hardware and software setup that is specific to each rangefinder is covered in their respective topics.
 
-The rangefinder is configured using [EKF2\_RNG\_*](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X) parameters. These configure information about the offset of the rangefinder from the centre of the vehicle body, the approximate delay of data reaching the estimator from the sensor, etc.
+The generic rangefinder configuration, covering both the physical setup and usage is covered below.
 
-### Enable/Use
 
-The rangefinder can be enabled in two ways:
-1. Set [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) to *Range finder* (`2`). This makes the rangefinder the primary source of height estimation (the default altitude sensor is the barometer).
-1. Set [EKF2_RNG_AID](../advanced_config/parameter_reference.md#EKF2_RNG_AID) to `1`. This makes the vehicle use the rangefinder as the primary source when it is safe to use, but will otherwise use the sensor specified in `EKF2_HGT_MODE`.
+### Generic Configuration
+
+The generic rangefinder configuration is specified using [EKF2\_RNG\_*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) parameters:
+These include (non exhaustively):
+- [EKF2_RNG_PITCH](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y), [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z) - Offset of the rangefinder from the centre of the vehicle body. 
+- [EKF2_RNG_DELAY](../advanced_config/parameter_reference.md#EKF2_RNG_DELAY) - approximate delay of data reaching the estimator from the sensor.
+- [EKF2\_RNG\_A\_\*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) - limits and consistency checks when using the sensor for the [range aid feature](../advanced_config/parameter_reference.md#feature).
+
+
+### Usage/Features {#features}
+
+Rangefinders can be enabled to support flight in two ways:
+1. Set [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) to *Range finder* (`2`). 
+   This makes the rangefinder the primary source of height estimation (the default altitude sensor is the barometer).
+1. Set [EKF2_RNG_AID](../advanced_config/parameter_reference.md#EKF2_RNG_AID) to `1`. 
+   This makes the vehicle use the rangefinder as the primary source when it is safe to use, but will otherwise use the sensor specified in `EKF2_HGT_MODE`.
    * Specifically, the rangefinder is enabled when:
      * velocity < [EKF2_RNG_A_VMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_VMAX)
      * distance to ground < [EKF2_RNG_A_HMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_HMAX)
    * Other parameters affecting "Range aid" are prefixed with `EKF2\_RNG\_A\_`.
 
-## Testing
+## Testing {#testing}
 
-The easiest way to test the rangefinder is to vary the range and compare to the values detected by PX4. The sections below show some approaches to getting the measured range.
+The easiest way to test the rangefinder is to vary the range and compare to the values detected by PX4. 
+The sections below show some approaches to getting the measured range.
 
 ### QGroundControl Analyze Tool
 
-The *QGroundControl Analyze Tool* tool and *QGroundControl MAVLink Inspector* let you view messages sent from the vehicle, including `DISTANCE_SENSOR` information from the rangefinder. The main difference between the tools is that the *Analyze* tool can plot values in a graph.
+The *QGroundControl Analyze Tool* tool and *QGroundControl MAVLink Inspector* let you view messages sent from the vehicle, including `DISTANCE_SENSOR` information from the rangefinder.
+The main difference between the tools is that the *Analyze* tool can plot values in a graph.
 
-> **Note** The messages that are sent depend on the vehicle configuration. You will only get `DISTANCE_SENSOR` messages if the connected vehicle has a rangefinder installed and is publishing sensor values.
+> **Note** The messages that are sent depend on the vehicle configuration. 
+  You will only get `DISTANCE_SENSOR` messages if the connected vehicle has a rangefinder installed and is publishing sensor values.
 
 To view the rangefinder output:
 
@@ -113,12 +123,13 @@ You can also use the *QGroundControl MAVLink Console* to observe the `distance_s
 listener distance_sensor 5
 ```
 
-> **Note** The *QGroundControl MAVLink Console* works when connected to Pixhawk or other NuttX targets, but not the Simulator. On the Simulator you can run the commands directly in the terminal.
+> **Note** The *QGroundControl MAVLink Console* works when connected to Pixhawk or other NuttX targets, but not the Simulator. 
+  On the Simulator you can run the commands directly in the terminal.
 
 For more information see: [Sensor/Topic Debugging using the Listener Command](https://dev.px4.io/en/debug/sensor_uorb_topic_debugging.html) (PX4 Development Guide).
 
 
-## Simulation
+## Simulation {#simulation}
 
 Lidar and sonar rangefinders can be used in the [Gazebo Simulator](https://dev.px4.io/en/simulation/gazebo.html) (PX4 Development Guide).
 To do this you must start the simulator using a vehicle model that includes the rangefinder.
@@ -133,7 +144,8 @@ The typhoon_h480 includes a sonar rangefinder:
 make px4_sitl gazebo_typhoon_h480
 ```
 
-If you need to use a different vehicle you can include the model in its configuration file. You can see how in the respective Iris and Typhoon configuration files:
+If you need to use a different vehicle you can include the model in its configuration file. 
+You can see how in the respective Iris and Typhoon configuration files:
 - [iris_opt_flow.sdf](https://github.com/PX4/sitl_gazebo/blob/master/models/iris_opt_flow/iris_opt_flow.sdf)
   ```xml
     <include>

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -67,3 +67,7 @@ Then set the [SENS_EN_SF0X](../advanced_config/parameter_reference.md#SENS_EN_SF
 * `3`: SF10/b
 * `4`: SF10/c
 * `5`: SF11/c
+
+## Further Information
+
+- [Modules Reference: Distance Sensor (Driver) : sf1xx](https://dev.px4.io/en/middleware/modules_driver_distance_sensor.html#sf1xx) (PX4 Dev Guide)

--- a/en/sensor/teraranger.md
+++ b/en/sensor/teraranger.md
@@ -1,0 +1,41 @@
+# TeraRanger Rangefinders
+
+TeraRanger provide a number of lightweight distance measurement sensor based on infrared Time-of-Flight (ToF) technology. 
+They are typically faster and have greater range than sonar, and smaller and lighter than laser-based systems.
+
+PX4 supports:
+* [TeraRanger One](http://www.teraranger.com/products/teraranger-one/) (0.2 - 14 m) (Requires an [I2C adapter](http://www.teraranger.com/product/teraranger-i2c-adapter/))
+* [TeraRanger Evo 60m](https://www.terabee.com/portfolio-item/teraranger-evo-infrared-distance-sensor/) (0.5 – 60 m)
+* TeraRanger Evo 600Hz (0.75 - 8 m)
+
+
+> **Info** The *Terranger One* is used in the [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md).
+
+
+## Where to Buy
+
+* TBD
+
+## Pinouts
+
+
+
+## Wiring
+
+All TeraRanger sensors must be connected via the I2C bus.
+
+While TeraRanger One requires an [I2C adapter](http://www.teraranger.com/product/teraranger-i2c-adapter/) any sensor from TeraRanger Evo series can be connected directly to the autopilot.
+
+
+## Software Configuration
+
+The sensors are enabled using the parameter [SENS_EN_TRANGER](../advanced_config/parameter_reference.md#SENS_EN_TRANGER) (you can set the type of sensor or that PX4 should auto-detect the type).
+
+> **Note** If using auto-detect for Evo sensors the minimum and maximum values for the range are set to the lowest and highest possible readings across the Evo family (currently 0.5 - 60 m). 
+In order to use the correct max/min values the appropriate model of the Evo sensor should be set in the parameter (instead of using autodetect).
+
+> **Tip** The driver for this rangefinder is usually present in firmware. If missing, you would also need to add the driver (`drivers/ll40ls`) to the board configuration.
+
+## Further Information
+
+* [Modules Reference: Distance Sensor (Driver) : teraranger](https://dev.px4.io/en/middleware/modules_driver_distance_sensor.html#teraranger) (PX4 Dev Guide)


### PR DESCRIPTION
These are changes I want to make to improve text and consistency in rangefinder docs before making real content changes. 

Things like splitting out teraranger info into own page.