### PR TITLE
Clarify rangefinder usage options

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -78,6 +78,7 @@
     * [Mission](flight_modes/mission.md)
     * [Follow Me](flight_modes/follow_me.md)
     * [Offboard](flight_modes/offboard.md)
+  * [Terrain Following/Holding](flying/terrain_following_holding.md)
 * [Flight Log Analysis](log/flight_log_analysis.md)
   * [Log Analysis using Flight Review](log/flight_review.md)
 * [Advanced Features](advanced_features/README.md)
@@ -133,7 +134,6 @@
     * [Benewake TFmini Lidar](sensor/tfmini.md)
     * [Lidar-Lite](sensor/lidar_lite.md)
     * [TeraRanger](sensor/teraranger.md)
-    
   * [Airspeed Sensors](sensor/airspeed.md)
   * [Optical Flow](sensor/optical_flow.md)
     * [PX4FLOW](sensor/px4flow.md)

--- a/en/flying/README.md
+++ b/en/flying/README.md
@@ -11,5 +11,6 @@ It covers both (autopilot-assisted) manual flight and mission planning for fully
 
 [Flight Modes](../flight_modes/README.md) — Summary table + detailed information about flight modes.
 
-
+[Terrain Follow/Hold & Range Assistance](../flying/terrain_following_holding.md) — How to enable terrain following.
+  
 > **Tip** [Vehicle Status Notifications](../getting_started/vehicle_status.md) can help you work out when your vehicle is ready to fly (and if not, why not).

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -1,0 +1,40 @@
+# Terrain Following/Holding
+
+PX4 supports *Terrain Following* and *Terrain Hold* on **multicopters** that have a [distance sensor](../sensor/rangefinders.md).
+
+The features are available in manual altitude-control modes: [Position](../flight_modes/position_mc.md), [Altitude](../flight_modes/altitude_mc.md).
+They are not available in acrobatic modes or automatic modes (e.g. Return, Land, Mission, etc.).
+
+## Terrain Following
+
+Terrain-following allows a low-flying vehicle to automatically maintain a (relatively) constant altitude above ground level.
+It is useful for avoiding obstacles when traveling over varied terrain, and for maintaining constant height for aerial photography.
+
+In this mode:
+- At low altitude the vehicle moves up and down with terrain height variation (using the distance sensor for altitude data while within its effective range).
+- At higher altitudes the vehicle will typically fly at a near-constant height above mean sea level (AMSL) using the barometer for altitude data.
+  > **Note** More precisely, the vehicle will use the *primary source of altitude data* as defined in [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE).
+    This is, by default, the barometer.
+
+## Terrain Hold
+
+Terrain-holding helps a vehicle to better hold/track altitude in [Position](../flight_modes/position_mc.md) or [Altitude](../flight_modes/altitude_mc.md) modes when horizontally stationary at low altitude.
+This allows a vehicle to avoid altitude changes due to barometer drift or excessive baro interference from rotor wash.
+
+In this mode:
+- When stationary (horizontally) the vehicle uses the distance sensor for altitude data (while within its effective range).
+- When moving (`speed > MPC_HOLD_MAX_XY`) or at higher altitudes the vehicle gets altitude data from the *primary source of altitude data* ( [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE)).
+
+
+> **Tip** *Range Aid* ([EKF2_RNG_AID=1](../advanced_config/parameter_reference.md#EKF2_RNG_AID)) has similar behaviour to terrain hold, but operates in all flight modes.
+
+
+## Setup
+
+Both terrain following and hold features require a [distance sensor](../sensor/rangefinders.md).
+Set up and activation/enabling of the sensor depends on the specific device (see docs for each sensor).
+The generic configuration that is common to all rangefinders (e.g. setting the position offset relative to the frame) is covered in [Distance Sensor > Configuration/Setup](../sensor/rangefinders.md#configuration).
+
+Terrain following and holding are then enabled using [MPC_ALT_MODE](../advanced_config/parameter_reference.md#MPC_ALT_MODE):
+- `MPC_ALT_MODE=1` - Terrain Following enabled
+- `MPC_ALT_MODE=2` - Terrain Holding enabled

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -26,7 +26,7 @@ Terrain following is enabled by setting [MPC_ALT_MODE](../advanced_config/parame
 Terrain holding uses a distance sensor to help a vehicle to better maintain a constant height above ground in [position](../flight_modes/position_mc.md) or [altitude](../flight_modes/altitude_mc.md) modes, when horizontally stationary at low altitude.
 This allows a vehicle to avoid altitude changes due to barometer drift or excessive barometer interference from rotor wash.
 
-> **Note** Terrain hold is enabled only in *multicopters* and *VTOL vehicles in MC mode*, and can be used in [position](../flight_modes/position_mc.md) and [altitude modes](../flight_modes/altitude_mc.md).
+> **Note** Terrain hold is enabled only in *multicopters* and *VTOL vehicles in MC mode*.
 
 When moving horizontally (`speed >` [MPC_HOLD_MAX_XY](../advanced_config/parameter_reference.md#MPC_HOLD_MAX_XY), or above the altitude where the distance sensor is providing valid data, the vehicle will switch into *altitude following*.
 
@@ -46,7 +46,7 @@ This may be useful when no barometer is available, or for applications when the 
 
 When using a distance sensor as the primary source of height, fliers should be aware:
 - Flying over obstacles can lead to the estimator rejecting rangefinder data (due to internal data consistency checks), which can result in poor altitude holding while the estimator 
-  is relying purely on accelerometer estimates. 
+  is relying purely on accelerometer estimates.
   > **Note** A scenario where this can occur is when the vehicle is ascending a slope at a near-constant height above ground;
     The altitude measured/estimated from the rangefinder does not change while that from the accelerometer does (i.e. they are not consistent).
 - The local NED origin will move up and down with ground level.
@@ -72,10 +72,3 @@ Range aid is further configured using the `EKF2_RNG_A_` parameters:
 - [EKF2_RNG_A_VMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_VMAX): Maximum horizonatal speed, above which range aid is disabled.
 - [EKF2_RNG_A_HMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_HMAX): Maximum height, above which range aid is disabled.
 - [EKF2_RNG_A_IGATE](../advanced_config/parameter_reference.md#EKF2_RNG_A_IGATE): Range aid consistency checks "gate" (a measure of the error before range aid is disabled).
-
-
-   <!-- 
-If vehicle motion causes repeated switching between the primary height sensor and range finder, an offset in the local position origin can accumulate. 
-Also range finder measurements are less reliable and can experience unexpected errors.
-
--->

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -51,6 +51,7 @@ When using a distance sensor as the primary source of height, fliers should be a
     The altitude measured/estimated from the rangefinder does not change while that from the accelerometer does (i.e. they are not consistent).
 - The local NED origin will move up and down with ground level.
 - Rangefinder performance over uneven surfaces (e.g. trees) can be very poor, resulting in noisy and inconsistent data.
+  This again leads to poor altitude hold.
 
 The feature is enabled by setting: [EKF2_HGT_MODE=2](../advanced_config/parameter_reference.md#EKF2_HGT_MODE).
 

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -45,10 +45,10 @@ This may be useful when no barometer is available, or for applications when the 
 > **Tip** The default and preferred altitude sensor for most use cases is the barometer (when available).
 
 When using a distance sensor as the primary source of height, fliers should be aware:
-- Flying over obstacles can lead to the estimator rejecting data (due to internal data consistency checks).
-  This will result in TBD.
+- Flying over obstacles can lead to the estimator rejecting rangefinder data (due to internal data consistency checks), which can result in poor altitude holding while the estimator 
+  is relying purely on accelerometer estimates. 
   > **Note** A scenario where this can occur is when the vehicle is ascending a slope at a near-constant height above ground;
-    The measured/estimated altitude does not change, but consistency checks show an error against the barometer measurements.
+    The altitude measured/estimated from the rangefinder does not change while that from the accelerometer does (i.e. they are not consistent).
 - The local NED origin will move up and down with ground level.
 - Rangefinder performance over uneven surfaces (e.g. trees) can be very poor, resulting in noisy and inconsistent data.
 

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -2,7 +2,7 @@
 
 PX4 supports [Terrain Following](#terrain_following) and [Terrain Hold](#terrain_hold) in [Position](../flight_modes/position_mc.md) and [Altitude modes](../flight_modes/altitude_mc.md), on *multicopters* and *VTOL vehicles in MC mode* that have a [distance sensor](../sensor/rangefinders.md).
 
-PX4 also supports [using a distance sensor as the primary source of altitude data](#distance_sensor_primary_altitude_source) in any mode, either all the time, or just when flying at low altitudes ([Range Aid](#range_aid)).
+PX4 also supports [using a distance sensor as the primary source of altitude data](#distance_sensor_primary_altitude_source) in any mode, either all the time, or just when flying at low altitudes at low velocities ([Range Aid](#range_aid)).
 
 
 ## Terrain Following {#terrain_following}
@@ -28,13 +28,12 @@ This allows a vehicle to avoid altitude changes due to barometer drift or excess
 
 > **Note** Terrain hold is enabled only in *multicopters* and *VTOL vehicles in MC mode*, and can be used in [position](../flight_modes/position_mc.md) and [altitude modes](../flight_modes/altitude_mc.md).
 
-When moving horizontally (`speed >` [MPC_HOLD_MAX_XY](../advanced_config/parameter_reference.md#MPC_HOLD_MAX_XY), or above the altitude where the distance sensor is providing valid data, the vehicle will instead use the *primary source of altitude data* ([EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE)).
-Typically this is the barometer.
+When moving horizontally (`speed >` [MPC_HOLD_MAX_XY](../advanced_config/parameter_reference.md#MPC_HOLD_MAX_XY), or above the altitude where the distance sensor is providing valid data, the vehicle will switch into *altitude following*.
 
 Terrain holding is enabled by setting [MPC_ALT_MODE](../advanced_config/parameter_reference.md#MPC_ALT_MODE) to `2`.
 
 > **Note** *Terrain hold* is implemented similarly to *terrain following.
-  It uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using another estimator) to provide the altitude setpoint.
+  It uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using separate, single state terrain estimator) to provide the altitude setpoint.
   As the distance to ground changes due to external forces, the altitude setpoint adjusts to keep the height above ground constant.
 
 

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -2,15 +2,17 @@
 
 PX4 supports [Terrain Following](#terrain_following) and [Terrain Hold](#terrain_hold) in [Position](../flight_modes/position_mc.md) and [Altitude modes](../flight_modes/altitude_mc.md), on *multicopters* and *VTOL vehicles in MC mode* that have a [distance sensor](../sensor/rangefinders.md).
 
-PX4 also supports [using a distance sensor as the primary source of altitude data](#distance_sensor_primary_altitude_source) in any mode, either all the time, or just when flying at low altitudes at low velocities ([Range Aid](#range_aid)).
+PX4 also supports using a *distance sensor* as the [primary source of altitude data](#distance_sensor_primary_altitude_source) in any mode, either all the time, or just when flying at low altitudes at low velocities ([Range Aid](#range_aid)).
 
 
 ## Terrain Following {#terrain_following}
 
-When *terrain following* is enabled, a vehicle will automatically maintain a relatively constant height above *ground level* if traveling at low altitudes.
-This is useful for avoiding obstacles and for maintaining constant height (e.g. for aerial photography) when flying over varied terrain.
+*Terrain following* enables a vehicle to automatically maintain a relatively constant height above ground level when traveling at low altitudes.
+This is useful for avoiding obstacles and for maintaining constant height when flying over varied terrain (e.g. for aerial photography).
 
-*Terrain following* uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using another estimator) to provide the altitude setpoint.
+> **Tip** This feature can be enabled in [Position](../flight_modes/position_mc.md) and [Altitude modes](../flight_modes/altitude_mc.md), on *multicopters* and *VTOL vehicles in MC mode* that have a [distance sensor](../sensor/rangefinders.md).
+
+When *terrain following* is enabled, PX4 uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using another estimator) to provide the altitude setpoint.
 As the distance to ground changes, the altitude setpoint adjusts to keep the height above ground constant.
 
 At higher altitudes (when the estimator reports that the distance sensor data is invalid) the vehicle switches to *altitude following*, and will typically fly at a near-constant height above mean sea level (AMSL) using the barometer for altitude data.
@@ -23,23 +25,23 @@ Terrain following is enabled by setting [MPC_ALT_MODE](../advanced_config/parame
 
 ## Terrain Hold {#terrain_hold}
 
-Terrain holding uses a distance sensor to help a vehicle to better maintain a constant height above ground in [position](../flight_modes/position_mc.md) or [altitude](../flight_modes/altitude_mc.md) modes, when horizontally stationary at low altitude.
+*Terrain hold* uses a distance sensor to help a vehicle to better maintain a constant height above ground in altitude control modes, when horizontally stationary at low altitude.
 This allows a vehicle to avoid altitude changes due to barometer drift or excessive barometer interference from rotor wash.
 
-> **Note** Terrain hold is enabled only in *multicopters* and *VTOL vehicles in MC mode*.
+> **Tip** This feature can be enabled in [Position](../flight_modes/position_mc.md) and [Altitude modes](../flight_modes/altitude_mc.md), on *multicopters* and *VTOL vehicles in MC mode* that have a [distance sensor](../sensor/rangefinders.md).
 
-When moving horizontally (`speed >` [MPC_HOLD_MAX_XY](../advanced_config/parameter_reference.md#MPC_HOLD_MAX_XY), or above the altitude where the distance sensor is providing valid data, the vehicle will switch into *altitude following*.
+When moving horizontally (`speed >` [MPC_HOLD_MAX_XY](../advanced_config/parameter_reference.md#MPC_HOLD_MAX_XY)), or above the altitude where the distance sensor is providing valid data, the vehicle will switch into *altitude following*.
 
 Terrain holding is enabled by setting [MPC_ALT_MODE](../advanced_config/parameter_reference.md#MPC_ALT_MODE) to `2`.
 
-> **Note** *Terrain hold* is implemented similarly to *terrain following.
-  It uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using separate, single state terrain estimator) to provide the altitude setpoint.
-  As the distance to ground changes due to external forces, the altitude setpoint adjusts to keep the height above ground constant.
+> **Note** *Terrain hold* is implemented similarly to [terrain following](#terrain_following).
+  It uses the output of the EKF estimator to provide the altitude estimate, and the estimated terrain altitude (calculated from distance sensor measurements using a separate, single state terrain estimator) to provide the altitude setpoint.
+  If the distance to ground changes due to external forces, the altitude setpoint adjusts to keep the height above ground constant.
 
 
 ## Distance Sensor as Primary Source of Height {#distance_sensor_primary_altitude_source}
 
-PX4 allows you to make a distance sensor the *primary source of altitude data*.
+PX4 allows you to make a distance sensor the *primary source of altitude data* (in any flight mode/vehicle type).
 This may be useful when no barometer is available, or for applications when the vehicle is *guaranteed* to only fly over a near-flat surface (e.g. indoors).
 
 > **Tip** The default and preferred altitude sensor for most use cases is the barometer (when available).
@@ -47,8 +49,12 @@ This may be useful when no barometer is available, or for applications when the 
 When using a distance sensor as the primary source of height, fliers should be aware:
 - Flying over obstacles can lead to the estimator rejecting rangefinder data (due to internal data consistency checks), which can result in poor altitude holding while the estimator 
   is relying purely on accelerometer estimates.
-  > **Note** A scenario where this can occur is when the vehicle is ascending a slope at a near-constant height above ground;
-    The altitude measured/estimated from the rangefinder does not change while that from the accelerometer does (i.e. they are not consistent).
+  > **Note** This scenario might occur when a vehicle ascends a slope at a near-constant height above ground, because the rangefinder altitude does not change while that estimated from the accelerometer does.<br>
+    The ECL performs innovation consistency checks that take into account the error between measurement and current state as well as the estimated variance of the state and the variance of the measurement itself.
+    If the checks fail the rangefinder data will be rejected, and the altitude will be estimated from the accelerometer.
+    After 5 seconds of inconsistent data the estimator resets the state (in this case height) to match the current distance sensor data.
+    The measurements might also become consistent again, for example, if the vehicle descends, or if the estimated height drifts to match the measured rangefinder height.
+    <!-- see discussion https://github.com/PX4/px4_user_guide/pull/457#pullrequestreview-221010392 -->
 - The local NED origin will move up and down with ground level.
 - Rangefinder performance over uneven surfaces (e.g. trees) can be very poor, resulting in noisy and inconsistent data.
   This again leads to poor altitude hold.
@@ -58,7 +64,7 @@ The feature is enabled by setting: [EKF2_HGT_MODE=2](../advanced_config/paramete
 
 ## Range Aid {#range_aid}
 
-*Range Aid* uses a distance sensor as the primary source of height estimation during low speed/low altitude operation, but will otherwise use the primary source of altitude data defined in [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) - typically the barometer.
+*Range Aid* uses a distance sensor as the primary source of height estimation during low speed/low altitude operation, but will otherwise use the primary source of altitude data defined in [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) (typically a barometer).
 It is primarily intended for *takeoff and landing*, in cases where the barometer setup is such that interference from rotor wash is excessive and can corrupt EKF state estimates.
 
 Range aid may also be used to improve altitude hold when the vehicle is stationary.

--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -68,31 +68,43 @@ PX4 also supports the Bebop rangefinder.
 ## Configuration/Setup {#configuration}
 
 Rangefinders are usually connected to either a serial (PWM) or I2C port (depending on the device driver), and are enabled on the port by setting a particular parameter.
-The hardware and software setup that is specific to each rangefinder is covered in their respective topics.
+The hardware and software setup that is *specific to each rangefinder* is covered in their respective topics.
 
-The generic rangefinder configuration, covering both the physical setup and usage is covered below.
+The generic configuration that is *common to all distance sensors*, covering both the physical setup and usage, is given below.
 
 
 ### Generic Configuration
 
-The generic rangefinder configuration is specified using [EKF2\_RNG\_*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) parameters:
+The common rangefinder configuration is specified using [EKF2\_RNG\_*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) parameters.
 These include (non exhaustively):
-- [EKF2_RNG_PITCH](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y), [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z) - Offset of the rangefinder from the centre of the vehicle body. 
+- [EKF2_RNG_PITCH](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y), [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z) - offset of the rangefinder from the centre of the vehicle body. 
 - [EKF2_RNG_DELAY](../advanced_config/parameter_reference.md#EKF2_RNG_DELAY) - approximate delay of data reaching the estimator from the sensor.
 - [EKF2\_RNG\_A\_\*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) - limits and consistency checks when using the sensor for the [range aid feature](../advanced_config/parameter_reference.md#feature).
 
 
 ### Usage/Features {#features}
 
-Rangefinders can be enabled to support flight in two ways:
-1. Set [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) to *Range finder* (`2`). 
-   This makes the rangefinder the primary source of height estimation (the default altitude sensor is the barometer).
-1. Set [EKF2_RNG_AID](../advanced_config/parameter_reference.md#EKF2_RNG_AID) to `1`. 
-   This makes the vehicle use the rangefinder as the primary source when it is safe to use, but will otherwise use the sensor specified in `EKF2_HGT_MODE`.
-   * Specifically, the rangefinder is enabled when:
-     * velocity < [EKF2_RNG_A_VMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_VMAX)
-     * distance to ground < [EKF2_RNG_A_HMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_HMAX)
-   * Other parameters affecting "Range aid" are prefixed with `EKF2\_RNG\_A\_`.
+Distance sensors can be enabled to support flight in several ways:
+1. Enable the *Range sensor* as the primary source of height estimation by setting [EKF2_HGT_MODE=2](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) (the default altitude sensor is the barometer). 
+   - This setting should only be used when for operation over a flat surface as the local NED origin will move up and down with ground level.
+   
+1. Enable *Range Aid* by setting [EKF2_RNG_AID=1](../advanced_config/parameter_reference.md#EKF2_RNG_AID). 
+   - This makes the vehicle use the rangefinder as the primary source of height estimation *when it is safe to use* (during low speed/low altitude operation), but will otherwise use the sensor specified in `EKF2_HGT_MODE`.
+   - It is primarily intended for takeoff and landing, where baro interference from rotor wash is excessive and can corrupt EKF state estimates. 
+   - Specifically, the rangefinder is enabled when:
+     - velocity < [EKF2_RNG_A_VMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_VMAX)
+     - distance to ground < [EKF2_RNG_A_HMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_HMAX)
+   - Other parameters affecting "Range aid" are prefixed with `EKF2_RNG_A_`.
+
+1. Enable rangefinder-supported *terrain following* by setting [MPC_ALT_MODE=1](../advanced_config/parameter_reference.md#MPC_ALT_MODE).
+   - In this mode the vehicle altitude moves up and down with terrain height variation.
+   - At altitudes above the distance sensor effective range the vehicle reverts to using height above the home position (as provided by the primary altitude source defined in `EKF2_HGT_MODE`).
+
+1. Enable rangefinder-supported *terrain holding* by setting [MPC_ALT_MODE=2](../advanced_config/parameter_reference.md#MPC_ALT_MODE).
+   - In this mode, when the vehicle is stationary its altitude is obtained from a distance sensor.
+   - When the vehicle is moving horizontally (`speed > MPC_HOLD_MAX_XY`) the altitude is provided relative to earth origin.
+   - At altitudes above the distance sensor effective range the vehicle reverts to always using height above the home position (as provided by the primary altitude source defined in `EKF2_HGT_MODE`).
+
 
 ## Testing {#testing}
 

--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -194,8 +194,3 @@ https://github.com/PX4/sitl_gazebo/blob/master/models/typhoon_h480/typhoon_h480.
       </axis>
     </joint>
   ```
-
-
-## Further Information
-
-* [Rangefinder](https://pixhawk.org/peripherals/rangefinder) (Pixhawk.org) - Rangefinders supported by Pixhawk

--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -1,6 +1,6 @@
 # Distance Sensors (Rangefinders)
 
-Distance sensors provide distance measurement that can be used for terrain following, precision hovering (e.g. for photography), warning of regulatory height limits, collision avoidance etc.
+Distance sensors provide distance measurement that can be used for [terrain following](../flying/terrain_following_holding.md#terrain_following), [terrain holding](../flying/terrain_following_holding.md#terrain_hold) (i.e. precision hovering for photography), improved landing behaviour ([range aid](../flying/terrain_following_holding.md#range_aid)), warning of regulatory height limits, collision prevention, etc.
 
 This section lists the distance sensors supported by PX4 (linked to more detailed documentation), the [generic configuration](#configuration) required for all rangefinders, [testing](#testing), and [simulation](#simulation) information.
 More detailed setup and configuration information is provided in the topics linked below (and sidebar).
@@ -68,7 +68,8 @@ PX4 also supports the Bebop rangefinder.
 ## Configuration/Setup {#configuration}
 
 Rangefinders are usually connected to either a serial (PWM) or I2C port (depending on the device driver), and are enabled on the port by setting a particular parameter.
-The hardware and software setup that is *specific to each rangefinder* is covered in their respective topics.
+
+The hardware and software setup that is *specific to each distance sensor* is covered in their individual topics.
 
 The generic configuration that is *common to all distance sensors*, covering both the physical setup and usage, is given below.
 
@@ -77,33 +78,12 @@ The generic configuration that is *common to all distance sensors*, covering bot
 
 The common rangefinder configuration is specified using [EKF2\_RNG\_*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) parameters.
 These include (non exhaustively):
-- [EKF2_RNG_PITCH](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y), [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z) - offset of the rangefinder from the centre of the vehicle body. 
+- [EKF2_RNG_POS_X](../advanced_config/parameter_reference.md#EKF2_RNG_POS_X), [EKF2_RNG_POS_Y](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Y), [EKF2_RNG_POS_Z](../advanced_config/parameter_reference.md#EKF2_RNG_POS_Z) - offset of the rangefinder from the vehicle centre of gravity in X, Y, Z directions.
+- [EKF2_RNG_PITCH](../advanced_config/parameter_reference.md#EKF2_RNG_PITCH) - A value of 0 degrees (default) corresponds to the range finder being exactly aligned with the vehicle vertical axis (i.e. straight down), while 90 degrees indicates that the range finder is pointing forward.
+  Simple trigonometry is used to calculate the distance to ground if a non-zero pitch is used.
 - [EKF2_RNG_DELAY](../advanced_config/parameter_reference.md#EKF2_RNG_DELAY) - approximate delay of data reaching the estimator from the sensor.
-- [EKF2\_RNG\_A\_\*](../advanced_config/parameter_reference.md#EKF2_RNG_AID) - limits and consistency checks when using the sensor for the [range aid feature](../advanced_config/parameter_reference.md#feature).
-
-
-### Usage/Features {#features}
-
-Distance sensors can be enabled to support flight in several ways:
-1. Enable the *Range sensor* as the primary source of height estimation by setting [EKF2_HGT_MODE=2](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) (the default altitude sensor is the barometer). 
-   - This setting should only be used when for operation over a flat surface as the local NED origin will move up and down with ground level.
-   
-1. Enable *Range Aid* by setting [EKF2_RNG_AID=1](../advanced_config/parameter_reference.md#EKF2_RNG_AID). 
-   - This makes the vehicle use the rangefinder as the primary source of height estimation *when it is safe to use* (during low speed/low altitude operation), but will otherwise use the sensor specified in `EKF2_HGT_MODE`.
-   - It is primarily intended for takeoff and landing, where baro interference from rotor wash is excessive and can corrupt EKF state estimates. 
-   - Specifically, the rangefinder is enabled when:
-     - velocity < [EKF2_RNG_A_VMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_VMAX)
-     - distance to ground < [EKF2_RNG_A_HMAX](../advanced_config/parameter_reference.md#EKF2_RNG_A_HMAX)
-   - Other parameters affecting "Range aid" are prefixed with `EKF2_RNG_A_`.
-
-1. Enable rangefinder-supported *terrain following* by setting [MPC_ALT_MODE=1](../advanced_config/parameter_reference.md#MPC_ALT_MODE).
-   - In this mode the vehicle altitude moves up and down with terrain height variation.
-   - At altitudes above the distance sensor effective range the vehicle reverts to using height above the home position (as provided by the primary altitude source defined in `EKF2_HGT_MODE`).
-
-1. Enable rangefinder-supported *terrain holding* by setting [MPC_ALT_MODE=2](../advanced_config/parameter_reference.md#MPC_ALT_MODE).
-   - In this mode, when the vehicle is stationary its altitude is obtained from a distance sensor.
-   - When the vehicle is moving horizontally (`speed > MPC_HOLD_MAX_XY`) the altitude is provided relative to earth origin.
-   - At altitudes above the distance sensor effective range the vehicle reverts to always using height above the home position (as provided by the primary altitude source defined in `EKF2_HGT_MODE`).
+- [EKF2_RNG_SFE](../advanced_config/parameter_reference.md#EKF2_RNG_SFE) - Range finder range dependant noise scaler.
+- [EKF2_RNG_NOISE](../advanced_config/parameter_reference.md#EKF2_RNG_NOISE) - Measurement noise for range finder fusion
 
 
 ## Testing {#testing}


### PR DESCRIPTION
This PR adds all the options for using rangefinder on PX4. I.e. specifically it adds `MPC_ALT_MODE` which was not previously mentioned.

The idea is that it should make it easier for people to find relevant docs if looking for information about terrain following while searching.