### PR TITLE
Flight Reporting: Improve and add link to QGC Log Streaming

### DIFF
--- a/en/getting_started/flight_reporting.md
+++ b/en/getting_started/flight_reporting.md
@@ -1,31 +1,38 @@
 # Flight Reporting
 
-PX4 logs detailed aircraft performance data once the system has been armed until it is disarmed. These flight logs can also be used to analyze performance issues.
+PX4 logs detailed aircraft state and sensor data, which can be used to analyze performance issues.
+This topic explains how you can download and analyse logs, and share them with the development team for review.
 
-> **Tip** Keeping flight logs is a legal requirement in some jurisdictions. 
+> **Tip** Keeping flight logs is a legal requirement in some jurisdictions.
 
 ## Downloading Logs from the Flight Controller
 
-Logs can be downloaded using [QGroundControl](http://qgroundcontrol.com/) (v3.2 or later): **[Analyze View > Log Download](https://docs.qgroundcontrol.com/en/analyze_view/log_download.html)**.
+Logs can be downloaded using [QGroundControl](http://qgroundcontrol.com/): **[Analyze View > Log Download](https://docs.qgroundcontrol.com/en/analyze_view/log_download.html)**.
 
 ![Flight Log Download](../../assets/qgc/analyze/log_download.jpg)
 
 
 ## Analyzing the Logs
 
-Upload the log file to the online [Flight Review](http://logs.px4.io) tool (http://logs.px4.io).
+Upload the log file to the online *Flight Review* tool (http://logs.px4.io).
+After upload you'll emailed a link to the analysis page for the log.
 
 [Log Analysis using Flight Review](../log/flight_review.md) explains how to interpret the plots, and can help you to verify/reject the causes of common problems: excessive vibration, poor PID tuning, saturated controllers, imbalanced vehicles, GPS noise, etc.
 
-> **Note** [Flight Log Analysis](../log/flight_log_analysis.md) contains links to information about many other useful logging tools.
+> **Note** There are many other great tools for visualising and analysing PX4 Logs.
+  For more information see: [Flight Analysis](../log/flight_log_analysis.md).
+  
+<span></span>
+> **Tip** If you have a constant high-rate MAVLink connection to the vehicle (not just a telemetry link) then you can use *QGroundControl* to automatically upload logs directly to *Flight Review*.
+  For more information see [Settings > MAVLink Settings > MAVLink 2 Logging (PX4 only)](https://docs.qgroundcontrol.com/en/SettingsView/MAVLink.html#logging).
 
 
 ## Sharing the Log Files for Review by PX4 Developers
 
-After uploading a file to [Flight Review](http://logs.px4.io), the log file link can be shared for discussion in the [support forums](../README.md#support) or a [Github issue](../README.md#reporting-bugs--issues).
+The [Flight Review](http://logs.px4.io) log file link can be shared for discussion in the [support forums](../README.md#support) or a [Github issue](../README.md#reporting-bugs--issues).
 
 
-## Additional Configuration
+## Log Configuration
 
 The logging system is configured by default to collect sensible logs for use with [Flight Review](http://logs.px4.io).
 
@@ -42,3 +49,8 @@ Parameter | Description
   (you would use this, for example, if you want to log your own topics).
   For more information see: [Logging](https://dev.px4.io/en/log/logging.html) (PX4 Developer Guide).
 
+## Key Links
+
+- [Flight Review](http://logs.px4.io)
+- [Log Analysis using Flight Review](../log/flight_review.md)
+- [Flight Log Analysis](../log/flight_log_analysis.md)


### PR DESCRIPTION
@bkueng This replaces #458 - captures some of the improvements from there and adds a mention of QGC MAVLink 2 log streaming. Also see https://github.com/mavlink/qgc-user-guide/pull/208 for the associated QGC doc update.