### PR TITLE
Remove SYS_LOGGER references

### DIFF
--- a/en/advanced_config/sensor_thermal_calibration.md
+++ b/en/advanced_config/sensor_thermal_calibration.md
@@ -62,7 +62,6 @@ To perform an offboard calibration:
 1. Ensure the frame type is set before calibration, otherwise calibration parameters will be lost when the board is setup.
 1. Power up the board and set the `TC_A_ENABLE`, `TC_B_ENABLE` and `TC_G_ENABLE` parameters to 1.
 1. Set all [CAL_GYRO*](../advanced_config/parameter_reference.md#CAL_GYRO0_EN) and [CAL_ACC*](../advanced_config/parameter_reference.md#CAL_ACC0_EN) parameters to defaults.
-1. Set the [SYS_LOGGER](../advanced_config/parameter_reference.md#SYS_LOGGER) parameter to 1 to use the new system logger.
 1. Set the [SDLOG_MODE](../advanced_config/parameter_reference.md#SDLOG_MODE) parameter to 2 to enable logging of data from boot. 
 1. Set the [SDLOG_PROFILE](../advanced_config/parameter_reference.md#SDLOG_PROFILE) checkbox for *thermal calibration* (bit 2) to log the raw sensor data required for calibration.
 1. Cold soak the board to the minimum temperature it will be required to operate in.

--- a/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/en/advanced_config/tuning_the_ecl_ekf.md
@@ -202,9 +202,7 @@ For this reason, no claims for accuracy relative to the legacy combination of `a
 ## How do I check the EKF performance?
 
 EKF outputs, states and status data are published to a number of uORB topics which are logged to the SD card during flight. 
-The following guide assumes that data has been logged using the *.ulog file format*. To use the *.ulog* format, set the SYS\_LOGGER parameter to 1.
-
-The .ulog format data can be parsed in python by using the [PX4 pyulog library](https://github.com/PX4/pyulog).
+The following guide assumes that data has been logged using the *.ulog file format*. The .ulog format data can be parsed in python by using the [PX4 pyulog library](https://github.com/PX4/pyulog).
 
 Most of the EKF data is found in the [ekf2_innovations](https://github.com/PX4/Firmware/blob/master/msg/ekf2_innovations.msg) and [estimator\_status](https://github.com/PX4/Firmware/blob/master/msg/estimator_status.msg) uORB messages that are logged to the .ulog file.
 


### PR DESCRIPTION
Quick corrections I found while reading the guide:
The parameter `SYS_LOGGER` is deprecated because the logger fully replaced sdlog2.
See e.g. https://github.com/PX4/Firmware/commit/6a49d78c4b353c8939b9361754f7f03c652e0b49

FYI @bkueng 