### PR TITLE
Update HKPilot32.md to specify connector type

### DIFF
--- a/en/flight_controller/HKPilot32.md
+++ b/en/flight_controller/HKPilot32.md
@@ -39,6 +39,7 @@ As a CC-BY-SA 3.0 licensed Open Hardware design, schematics and design files sho
 * RSSI (PWM or voltage) input
 * SPI
 * External microUSB port
+* Molex PicoBlade connectors
 
 ### Accessories
 


### PR DESCRIPTION
The HKPilot32 uses Molex PicoBlade connectors while the original Pixhawk (3DR and mRo)
uses Hirose DF13 connectors.