### PR TITLE
pixhawk-2: fix ADC description

### DIFF
--- a/en/flight_controller/pixhawk-2.md
+++ b/en/flight_controller/pixhawk-2.md
@@ -64,7 +64,7 @@ Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as
 * RSSI (PWM or voltage) input
 * I2C
 * SPI
-* 3.3 and 6.6V ADC inputs
+* 3.3v ADC input
 * Internal microUSB port and external microUSB port extension
 
 ### Power System and Protection


### PR DESCRIPTION
Apparently this was a type and there is only one 3v3 ADC.

This came up in http://discuss.px4.io/t/inquiry-about-the-pixhawk-adc-6-6v/10448.

We should probably check the description of the other Pixhawks as well.