### PR TITLE
serial_configuration - fix up the board configuration location

### DIFF
--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -61,10 +61,10 @@ If a parameter is missing, then you may need to add it in firmware.
 > **Note** PX4 firmware includes most drivers by default on [Pixhawk-series](../flight_controller/pixhawk_series.md) boards.
   Flash-limited boards may comment out/omit the driver (at time of writing this only affects boards based on FMUv2).
 
-You can include the missing driver in firmware by uncommenting (or adding) the driver in the [cmake config file](https://github.com/PX4/Firmware/tree/master/cmake/configs) that corresponds to the target you want to build for. 
-For example, to enable the leddar_one driver, you would remove the `#` at the beginning of the line below.
+You can include the missing driver in firmware by uncommenting (or adding) the driver in the **default.cmake** config file that corresponds to the [board](https://github.com/PX4/Firmware/tree/master/boards/px4) you want to build for. 
+For example, to enable the sf0x driver, you would remove the `#` at the beginning of the line below.
 ```
-#drivers/distance_sensor/leddar_one
+#distance_sensor/sf0x
 ```
 
 You will then need to build the firmware for your platform, as described in [Building PX4 Software](https://dev.px4.io/en/setup/building_px4.html) (PX4 Development Guide).


### PR DESCRIPTION
Config files moved under board definitions. This fixes up link to where default.cmake for each board is now kept.