### PR TITLE
Bump MavLink ESP8266 Firmware version to 1.2.2

### DIFF
--- a/en/telemetry/esp8266_wifi_module.md
+++ b/en/telemetry/esp8266_wifi_module.md
@@ -29,7 +29,7 @@ The [firmware repository](https://github.com/dogmaphobic/mavesp8266) contains in
 
 ### Pre Built Binaries
 
-[MavLink ESP8266 Firmware V 1.1.1](http://www.grubba.com/mavesp8266/firmware-1.1.1.bin)
+[MavLink ESP8266 Firmware V 1.2.2](http://www.grubba.com/mavesp8266/firmware-1.2.2.bin)
 
 ### Updating the Firmware
 


### PR DESCRIPTION
Use Mavlink V2 version firware for PX4 usage.

https://github.com/dogmaphobic/mavesp8266