### PR TITLE
FlightREview: Add general refs re vibration analysis

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -15,6 +15,7 @@
   * [Flight Reporting](getting_started/flight_reporting.md)
 * [Basic Assembly](assembly/README.md)
   * [Mounting the Flight Controller](assembly/mount_and_orient_controller.md)
+  * [Vibration Isolation](assembly/vibration_isolation.md)
   * [Pixhawk 4 Wiring Quickstart](assembly/quick_start_pixhawk4.md)
   * [Pixhawk 4 Mini Wiring Quickstart](assembly/quick_start_pixhawk4_mini.md)
   * [Cube Wiring Quickstart](assembly/quick_start_cube.md)

--- a/en/assembly/mount_and_orient_controller.md
+++ b/en/assembly/mount_and_orient_controller.md
@@ -21,4 +21,4 @@ Some boards include in-built vibration-isolation, while others come with *mounti
 
 You should use the mounting strategy recommended in your flight controller documentation.
 
-> **Tip** [Log Analysis using Flight Review > Vibration](../log/flight_review.md#vibration) explains how to test whether vibration levels are acceptable, and suggests a number of possible [solutions](../log/flight_review.md#solutions) if there is a problem.
+> **Tip** [Log Analysis using Flight Review > Vibration](../log/flight_review.md#vibration) explains how to test whether vibration levels are acceptable, and [Vibration Isolation](../assembly/vibration_isolation.md) suggests a number of possible solutions if there is a problem.

--- a/en/assembly/vibration_isolation.md
+++ b/en/assembly/vibration_isolation.md
@@ -19,12 +19,12 @@ Further isolation may be needed in order to reduce vibration to the level that s
 ## Basic Vibration Fixes
 
 A few of simple steps that may reduce vibrations are:
-- Use a vibration-isolation method to mount the autopilot.
-  Many flight controllers come with *mounting foam* that you can use for this purpose, while others have inbuilt vibration-isolation mechanisms.
 - Make sure everything is firmly attached on the vehicle (landing gear, GPS mast, etc.).
 - Use balanced propellers.
 - Make sure to use high-quality components for the propellers, motors, ESC and airframe.
   Each of these components can make a big difference.
+- Use a vibration-isolation method to mount the autopilot.
+  Many flight controllers come with *mounting foam* that you can use for this purpose, while others have inbuilt vibration-isolation mechanisms.
 - As a *last* measure, adjust the software filters (see [here](../config_mc/racer_setup.md#filters)).
   It is better to reduce the source of vibrations, rather than filtering them out in software.
   

--- a/en/assembly/vibration_isolation.md
+++ b/en/assembly/vibration_isolation.md
@@ -5,7 +5,7 @@ This topic shows how to determine whether vibration levels are too high, and lis
 ## Overview
 
 Flight Control boards with in-built accelerometers or gyros are sensitive to vibrations.
-High vibration levels can cause sensor clipping and sensor failures, resulting in a range of problems, from reduced flight efficiency/performance (leading to shorter flights and increased vehicle wear-and-tear), through to fly-aways and crashes.
+High vibration levels can cause a range of problems, including reduced flight efficiency/performance, shorter flight times and increased vehicle wear-and-tear. In extreme cases vibration may lead to sensor clipping/failures, possibly resulting in estimation failures and fly-aways.
 
 Well-designed airframes damp/reduce the amplitude of specific structural resonances at the autopilot mounting location.
 Further isolation may be needed in order to reduce vibration to the level that sensitive components can handle (e.g. some flight controllers must be attached to the airframe using some form of anti-vibration foam/mount - while others are internally isolated).

--- a/en/assembly/vibration_isolation.md
+++ b/en/assembly/vibration_isolation.md
@@ -1,0 +1,36 @@
+# Vibration Isolation
+
+This topic shows how to determine whether vibration levels are too high, and lists some simple steps to improve vibration performance.
+
+## Overview
+
+Flight Control boards with in-built accelerometers or gyros are sensitive to vibrations.
+High vibration levels can cause sensor clipping and sensor failures, resulting in a range of problems, from reduced flight efficiency/performance (leading to shorter flights and increased vehicle wear-and-tear), through to fly-aways and crashes.
+
+Airframes are designed to damp/reduce the amplitude of specific structural resonances at the autopilot mounting location.
+Users should further isolate the flight controller from airframe (using foam or some other isolation mount) in order to reduce vibration to the level that the autopilot can handle.
+
+
+## Vibration Analysis
+
+[Log Analysis using Flight Review > Vibration](../log/flight_review.md#vibration) explains how to use logs to confirm whether vibration is a probable cause of flight problems.
+
+
+## Basic Vibration Fixes
+
+A few of simple steps that may reduce vibrations are:
+- Use a vibration-isolation method to mount the autopilot.
+  Many flight controllers come with *mounting foam* that you can use for this purpose, while others have inbuilt vibration-isolation mechanisms.
+- Make sure everything is firmly attached on the vehicle (landing gear, GPS mast, etc.).
+- Use balanced propellers.
+- Make sure to use high-quality components for the propellers, motors, ESC and airframe.
+  Each of these components can make a big difference.
+- As a *last* measure, adjust the software filters (see [here](../config_mc/racer_setup.md#filters)).
+  It is better to reduce the source of vibrations, rather than filtering them out in software.
+  
+## References
+
+Some references that you may find useful are:
+- [An Introduction to Shock & Vibration Response Spectra, Tom Irvine](https://info.mide.com/hubfs/eBooks/ebook-tom-irvine-shock-vibration-response-spectra.pdf) (free ebook)
+- [Structural Dynamics and Vibration in Practice - An Engineering Handbook, Douglas Thorby](https://books.google.ch/books?id=PwzDuWDc8AgC&printsec=frontcover#v=onepage&q&f=false) (preview).
+

--- a/en/assembly/vibration_isolation.md
+++ b/en/assembly/vibration_isolation.md
@@ -1,6 +1,6 @@
 # Vibration Isolation
 
-This topic shows how to determine whether vibration levels are too high, and lists some simple steps to improve vibration performance.
+This topic shows how to determine whether vibration levels are too high, and lists some simple steps to improve vibration characteristics.
 
 ## Overview
 

--- a/en/assembly/vibration_isolation.md
+++ b/en/assembly/vibration_isolation.md
@@ -7,8 +7,8 @@ This topic shows how to determine whether vibration levels are too high, and lis
 Flight Control boards with in-built accelerometers or gyros are sensitive to vibrations.
 High vibration levels can cause sensor clipping and sensor failures, resulting in a range of problems, from reduced flight efficiency/performance (leading to shorter flights and increased vehicle wear-and-tear), through to fly-aways and crashes.
 
-Airframes are designed to damp/reduce the amplitude of specific structural resonances at the autopilot mounting location.
-Users should further isolate the flight controller from airframe (using foam or some other isolation mount) in order to reduce vibration to the level that the autopilot can handle.
+Well-designed airframes damp/reduce the amplitude of specific structural resonances at the autopilot mounting location.
+Further isolation may be needed in order to reduce vibration to the level that sensitive components can handle (e.g. some flight controllers must be attached to the airframe using some form of anti-vibration foam/mount - while others are internally isolated).
 
 
 ## Vibration Analysis

--- a/en/log/flight_review.md
+++ b/en/log/flight_review.md
@@ -181,19 +181,23 @@ Very high (unsafe) vibration levels.
 
 
 
-### Solutions
+### Fixing Vibration Problems (Solutions) {#solutions}
 
-Often a source of vibration cannot be identified from a log alone and the vehicle needs to be inspected.
+Often a source of vibration cannot be identified from logs alone, and the vehicle needs to be inspected.
 There can be a combination of multiple sources.
 
-Solutions and steps to reduce vibrations include:
-- Make sure everything is firmly attached on the vehicle (landing gear, GPS mast, etc.)
+A few of simple steps that can be taken to reduce vibrations are:
+- Make sure everything is firmly attached on the vehicle (landing gear, GPS mast, etc.).
 - Use balanced propellers.
 - Make sure to use high-quality components for the propellers, motors, ESC and airframe.
   Each of these components can make a big difference.
 - Use a vibration-isolation method to mount the autopilot.
 - As a *last* measure, adjust the software filters (see [here](../config_mc/racer_setup.md#filters)).
   It is better to reduce the source of vibrations, rather than filtering them out in software.
+  
+> **Tip** Vibration analysis is a deep and complex topic.
+  Two *general* references that you may find useful are: [An Introduction to Shock & Vibration Response Spectra, Tom Irvine](https://info.mide.com/hubfs/eBooks/ebook-tom-irvine-shock-vibration-response-spectra.pdf) (free ebook) and 
+[Structural Dynamics and Vibration in Practice - An Engineering Handbook, Douglas Thorby](https://books.google.ch/books?id=PwzDuWDc8AgC&printsec=frontcover#v=onepage&q&f=false) (preview).
 
 <!-- TODO: write a separate vibration setup page in more depth, move some of this there and link to it from here -->
 

--- a/en/log/flight_review.md
+++ b/en/log/flight_review.md
@@ -186,7 +186,7 @@ Very high (unsafe) vibration levels.
 Often a source of vibration (or combination of multiple sources) cannot be identified from logs alone.
 
 In this case the vehicle should be inspected.
-[Vibration Isolation](../assembly/vibration_isolation.md) explains some basic things you can check (and do) to improve vibration performance.
+[Vibration Isolation](../assembly/vibration_isolation.md) explains some basic things you can check (and do) to reduce vibration levels.
 
 
 

--- a/en/log/flight_review.md
+++ b/en/log/flight_review.md
@@ -181,25 +181,13 @@ Very high (unsafe) vibration levels.
 
 
 
-### Fixing Vibration Problems (Solutions) {#solutions}
+### Fixing Vibration Problems {#solutions}
 
-Often a source of vibration cannot be identified from logs alone, and the vehicle needs to be inspected.
-There can be a combination of multiple sources.
+Often a source of vibration (or combination of multiple sources) cannot be identified from logs alone.
 
-A few of simple steps that can be taken to reduce vibrations are:
-- Make sure everything is firmly attached on the vehicle (landing gear, GPS mast, etc.).
-- Use balanced propellers.
-- Make sure to use high-quality components for the propellers, motors, ESC and airframe.
-  Each of these components can make a big difference.
-- Use a vibration-isolation method to mount the autopilot.
-- As a *last* measure, adjust the software filters (see [here](../config_mc/racer_setup.md#filters)).
-  It is better to reduce the source of vibrations, rather than filtering them out in software.
-  
-> **Tip** Vibration analysis is a deep and complex topic.
-  Two *general* references that you may find useful are: [An Introduction to Shock & Vibration Response Spectra, Tom Irvine](https://info.mide.com/hubfs/eBooks/ebook-tom-irvine-shock-vibration-response-spectra.pdf) (free ebook) and 
-[Structural Dynamics and Vibration in Practice - An Engineering Handbook, Douglas Thorby](https://books.google.ch/books?id=PwzDuWDc8AgC&printsec=frontcover#v=onepage&q&f=false) (preview).
+In this case the vehicle should be inspected.
+[Vibration Isolation](../assembly/vibration_isolation.md) explains some basic things you can check (and do) to improve vibration performance.
 
-<!-- TODO: write a separate vibration setup page in more depth, move some of this there and link to it from here -->
 
 
 ## Actuator Outputs


### PR DESCRIPTION
Some references to general vibration analysis from @bresch: https://github.com/PX4/px4_user_guide/issues/434#issuecomment-492543293

These have been added to the "Solutions" section of the flight review for want of a better place.

Beat, do you think we might reasonably pull out this whole section and add it as a stand along doc under Basic assembly? I like the idea because this doc would then show up clearly in search and can be linked from several places. Only downside is that there isn't all that much information. At least it would become obvious where to put more information in future.

I am leaning towards this.