### PR TITLE
Safety: Clarify Data Link Loss applies in missions

### DIFF
--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -72,7 +72,7 @@ RC Loss Loiter Time | [NAV_RCL_LT](../advanced_config/parameter_reference.md#NAV
 
 ### Data Link Loss Failsafe
 
-The Data Link loss failsafe is triggered if a telemetry link (connection to ground station) is lost.
+The Data Link Loss failsafe is triggered if a telemetry link (connection to ground station) is lost when flying a [mission](../flying/missions.md).
 
 ![Safety - Data Link Loss (QGC)](../../images/qgc/setup/safety_data_link_loss.png)
 


### PR DESCRIPTION
As discussed in https://github.com/PX4/Firmware/issues/12015#issuecomment-493983484

I said "when flying a mission". I presume that we don't need to be very pedantic and say "when not landed in a mission"?