### PR TITLE
SFxxx rangefinder: separate out discontinued

### DIFF
--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -14,7 +14,6 @@ More detailed setup and configuration information is provided in the topics link
 [Lidar-Lite](../sensor/lidar_lite.md) is a compact, high-performance optical distant measurement rangefinder. 
 It has a sensor range from (5cm - 40m) and can be connected to either PWM or I2C ports.
 
-
 ### MaxBotix I2CXL-MaxSonar-EZ
 
 The MaxBotix [I2CXL-MaxSonar-EZ](https://www.maxbotix.com/product-category/i2cxl-maxsonar-ez-products) range has a number of relatively short-ranged sonar based rangefinders that are suitable for assisted takeoff/landing and collision avoidance. 
@@ -24,16 +23,10 @@ The rangefinders are enabled using the parameter [SENS_EN_MB12XX](../advanced_co
 
 ### Lightware LIDARs
 
-[Lightware SFxx Lidar](../sensor/sfxx_lidar.md) provide a range of lightweight "laser altimeters" that are suitable for many drone applications:
-* [SF02](http://lightware.co.za/shop2017/proximity-sensors/1-sf02f.html)
-* [SF10/A](http://lightware.co.za/shop2017/drone-altimeters/26-sf10a-25-m.html) (25 m)
-* [SF10/B](http://lightware.co.za/shop2017/drone-altimeters/25-sf10b-50-m.html) (50 m)
-* SF10/C (100m) (Discontinued)
-* [SF11/C](https://lightware.co.za/collections/lidar-rangefinders/products/sf11-c-120-m) (120 m)
-* [SF/LW20](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) (100 m) - Waterproofed (IP67) with servo for sense-and-avoid applications
+[Lightware SFxx Lidar](../sensor/sfxx_lidar.md) provide a broad range of lightweight "laser altimeters" that are suitable for many drone applications.
 
-Drivers exist for both I2C and serial ports (not all devices are supported for both serial and I2C).
-
+PX4 supports: SF11/c and SF/LW20.
+PX4 can also be used with the following discontinued models: SF02, SF10/a, SF10/b, SF10/c.
 
 ### TeraRanger Rangefinders
 

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -1,27 +1,36 @@
 # LightWare SF1X/SF02/LW20 Lidar
 
-LightWare develops a range of light-weight, general purpose, laser altimeters ("Lidar") suitable for mounting on UAVs. These are useful for applications including terrain following, precision hovering (e.g. for photography), warning of regulatory height limits, anti-collision sensing etc.
+LightWare develops a range of light-weight, general purpose, laser altimeters ("Lidar") suitable for mounting on UAVs.
+These are useful for applications including terrain following, precision hovering (e.g. for photography), warning of regulatory height limits, anti-collision sensing etc.
 
 ![LightWare SF11/C Lidar](../../assets/hardware/sensors/sf11c_120_m.jpg)
 
 ## Supported Models
 
-PX4 supports the following LightWare Lidar rangefinders:
-* [SF02](http://lightware.co.za/shop2017/proximity-sensors/1-sf02f.html) (50 m)
-* [SF10/A](http://lightware.co.za/shop2017/drone-altimeters/26-sf10a-25-m.html) (25 m)
-* [SF10/B](http://lightware.co.za/shop2017/drone-altimeters/25-sf10b-50-m.html) (50 m)
-* SF10/C (100m) (Discontinued)
-* [SF11/C](https://lightware.co.za/collections/lidar-rangefinders/products/sf11-c-120-m) (120 m)
-* [LW20](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) (100 m) - Waterproofed (IP67) with servo for sense-and-avoid applications
+The following models are supported by PX4, and can be connected to either the I2C or Serial bus (the tables below indicates what bus can be used for each model).
 
-The lidars can be connected to I2C or serial ports, depending on their type (see below)
-- **Serial**: SF02, SF10/a, SF10/b, SF10/c, SF11/c
-- **I2C**: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20
+### Available
+
+Model | Range (m) | Bus | Description
+--- | --- | --- | ---
+[SF11/C](https://lightware.co.za/collections/lidar-rangefinders/products/sf11-c-120-m) | 120 | Serial or I2C bus | 
+[LW20](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) | 100 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
+
+### Discontinued
+
+The following models are no longer available from the manufacturer.
+
+Model | Range | Bus
+--- | --- | ---
+[SF02](http://lightware.co.za/shop2017/proximity-sensors/1-sf02f.html) | 50 | Serial
+[SF10/A](http://lightware.co.za/shop2017/drone-altimeters/26-sf10a-25-m.html) | 25 | Serial or I2C
+[SF10/B](http://lightware.co.za/shop2017/drone-altimeters/25-sf10b-50-m.html) | 50 | Serial or I2C
+SF10/C | 100m | Serial or I2C
 
 
 ## I2C Setup
 
-The following models can be connected to the I2C port: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20
+Check the tables above to confirm that which models can be connected to the I2C port.
 
 ### Hardware {#i2c_hardware_setup}
 


### PR DESCRIPTION
A bunch of lightware rangefinders are no longer available from manufacturer. This identifies active vs discontinued and does some tidy of presentation. Partially fixes #488