### PR TITLE
PX4 Basic concepts: Remove Dronecode as a concept

### DIFF
--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -15,13 +15,9 @@ These include (non exhaustively): aerial photography/video, carrying cargo, raci
 > **Tip** Different types of drones exist for use in air, ground, sea, and underwater. 
 These are (more formally) referred to as Unmanned Aerial Vehicles (UAV), Unmanned Aerial Systems (UAS), Unmanned Ground Vehicles (UGV), Unmanned Surface Vehicles (USV), Unmanned Underwater Vehicles (UUV).
 
-The "brain" of the drone is called an autopilot. It consists of *flight stack* software running on *vehicle controller* ("flight controller") hardware.
+The "brain" of the drone is called an autopilot.
+It consists of *flight stack* software running on *vehicle controller* ("flight controller") hardware.
 
-
-## Dronecode Platform {#dronecode}
-
-PX4 is part of the [Dronecode Platform](https://www.dronecode.org/platform/) — a complete end-to-end platform for drone development, delivered under a common industry-friendly open source license.
-It includes, among other things, the [PX4 flight stack](#autopilot)), [QGroundControl](#qgc) ground control station, the [MAVSDK](https://www.dronecode.org/sdk/) and the [Dronecode Camera Manager](https://camera-manager.dronecode.org/en/).
 
 ## PX4 Autopilot {#autopilot}
 
@@ -32,6 +28,8 @@ Some of PX4's key features are:
 - Great choice of hardware for [vehicle controller](#vehicle_controller), sensors and other peripherals.
 - Flexible and powerful [flight modes](#flight_modes) and [safety features](#safety).
 
+PX4 is a core part of a broader drone platform that includes the [QGroundControl](#qgc) ground station, [Pixhawk hardware](https://pixhawk.org/), and [MAVSDK](http://mavsdk.mavlink.io) for integration with companion computers, cameras and other hardware using the MAVLink protocol.
+PX4 is supported by the [Dronecode Project](https://www.dronecode.org/).
 
 ## QGroundControl {#qgc}
 


### PR DESCRIPTION
This removes dronecode platform as its own section - we no longer talk so much of DC as the platform as PX4 being more than just a flight stack. 

I've moved the concept of PX4 as part of a broader platform inside the PX4 section and here I mention Dronecode.

@LorenzMeier are you OK with this positioning?