### PR TITLE
Add ADSB/Flarm docs

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -148,6 +148,7 @@
   * [Camera](peripherals/camera.md)
   * [Parachute](peripherals/parachute.md)
   * [Companion Computer Peripherals](peripherals/companion_computer_peripherals.md)
+  * [ADSB/FLARM (Traffic Avoidance)](peripherals/adsb_flarm.md)
 * [Autopilot Hardware](flight_controller/README.md)
   * [Pixhawk Series](flight_controller/pixhawk_series.md)
     * [Pixhawk 1](flight_controller/pixhawk.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -89,6 +89,7 @@
   * [RockBlock SatCom System](advanced_features/satcom_roadblock.md)
   * [Obstacle Avoidance](computer_vision/obstacle_avoidance.md)
   * [Collision Prevention](computer_vision/collision_prevention.md)
+  * [Air Traffic Avoidance: ADSB/FLARM](advanced_features/traffic_avoidance_adsb.md)
 * [Advanced Configuration](advanced_config/README.md)
   * [Parameters](advanced_config/parameters.md)
   * [Multicopter Config/Tuning](config_mc/README.md)

--- a/en/advanced_features/README.md
+++ b/en/advanced_features/README.md
@@ -7,3 +7,4 @@ This section contains topics related to some of the more advanced features of th
 * [Iridium/RockBlock Satellite Communication System](../advanced_features/satcom_roadblock.md)
 * [Obstacle Avoidance](../computer_vision/obstacle_avoidance.md) (needs companion computer)
 * [Collision Prevention](../computer_vision/collision_prevention.md)
+* [Air Traffic Avoidance: ADS-B/FLARM](../advanced_features/traffic_avoidance_adsb.md)

--- a/en/advanced_features/traffic_avoidance_adsb.md
+++ b/en/advanced_features/traffic_avoidance_adsb.md
@@ -1,22 +1,81 @@
 # Air Traffic Avoidance: ADS-B/FLARM
 
-PX4 uses [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast) and [FLARM](https://en.wikipedia.org/wiki/FLARM) transponders to support simple air traffic avoidance in [missions](../flight_modes/mission.md).
-If a potential collision is detected, PX4 can *warn*, immediately [land](../flight_modes/land.md), or [return](../flight_modes/return.md) - depending on the value of [NAV_TRAFF_AVOID](#NAV_TRAFF_AVOID).
+PX4 can use [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast) or [FLARM](https://en.wikipedia.org/wiki/FLARM) transponders to support simple air traffic avoidance in [missions](../flight_modes/mission.md).
+If a potential collision is detected, PX4 can *warn*, immediately [land](../flight_modes/land.md), or [return](../flight_modes/return.md) (depending on the value of [NAV_TRAFF_AVOID](#NAV_TRAFF_AVOID)).
 
 
-## Setup
+## Supported Hardware {#supported_hardware}
 
-### Hardware Setup
+PX4 traffic avoidance works with ADS-B or FLARM products that supply transponder data using the MAVLink [ADSB_VEHICLE](https://mavlink.io/en/messages/common.html#ADSB_VEHICLE) message.
+
+It has been tested with the following devices:
+- [PingRX ADS-B Receiver](https://uavionix.com/product/pingrx/) (uAvionix)
+- [FLARM](https://flarm.com/products/powerflarm/uav/)
 
 
+## Hardware Setup
 
-### Software Configuration (Parameters)
+Either device can can be connected to any free/unused serial port on the flight controller.
+Most commonly it they are connected to TELEM2 (if this is not being use for some other purpose).
+
+### PingRX
+
+The PingRX MAVLink port uses a JST ZHR-4 mating connector with pinout as shown below.
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | RX (IN)  | +5V tolerant
+2 (blk) | TX (OUT) | 
+3 (blk) | Power  | +4 to 6V
+4 (blk) | GND    | GND
+
+The PingRX comes with connector cable that can be attached directly to the TELEM2 port (DF13-6P) on an [mRo Pixhawk](../flight_controller/mro_pixhawk.md).
+For other ports or boards, you will need to obtain your own cable.
 
 
+## FLARM
+
+FLARM has an on-board DF-13 6 Pin connector that has an identical pinout to the [mRo Pixhawk](../flight_controller/mro_pixhawk.md).
+
+Pin | Signal | Volt
+--- | --- | ---
+1 (red) | VCC      | +4V to +36V
+2 (blk) | TX (OUT) | +3.3V
+3 (blk) | RX (IN)  | +3.3V
+4 (blk) | - | +3.3V
+5 (blk) | - | +3.3V
+6 (blk) | GND      | GND
+
+> **Note** The TX and RX on the flight controller must be connected to the RX and TX on the FLARM, respectively.
+
+
+## Software Configuration
+
+### Port Configuration
+
+Flarm/PingRX are configured in the same way as any other [MAVLink Peripheral](../peripherals/mavlink_peripherals.md). 
+The only *specific* setup is that the port baud rate must be set to 57600 and the a low-bandwidth profile (`MAV_X_MODE`).
+
+Assuming you have connected the device to the TELEM2 port, [set the parameters](../advanced_config/parameters.md) as shown:
+
+- [MAV_1_CONFIG](../advanced_config/parameter_reference.md#MAV_1_CONFIG) = TELEM 2
+- [MAV_1_MODE](../advanced_config/parameter_reference.md#MAV_1_MODE) = Normal
+- [MAV_1_RATE](../advanced_config/parameter_reference.md#MAV_1_RATE) = 0 (default sending rate for port).
+- [MAV_1_FORWARD](../advanced_config/parameter_reference.md#MAV_1_FORWARD) = Enabled
+  
+Then reboot the vehicle. 
+
+You will now find a new parameter called [SER_TEL2_BAUD](../advanced_config/parameter_reference.md#SER_TEL2_BAUD), which must be set to 57600.
+
+> **Note** Prior to PX4 v1.9 you can set up the port using the deprecated parameter: `SYS_COMPANION`.
+
+### Configure Traffic Avoidance
+
+Configure the action when there is a potential collision using the parameter below:
+
+Parameter | Description
+--- | ---
 <span id="NAV_TRAFF_AVOID"></span>[NAV_TRAFF_AVOID](../advanced_config/parameter_reference.md#NAV_TRAFF_AVOID) | Enable traffic avoidance mode specify avoidance response. 0: Disable, 1: Warn only, 2: Return mode, 3: Land mode.
-
-
-## Simulation/Testing
 
 
 
@@ -29,3 +88,10 @@ If they may then PX4 it estimates how the closest distance between the path to t
 If the crossing point is less that 500m for altitude and path distance (hard coded), the [Traffic Avoidance Failsafe](../config/safety.md#traffic_avoidance) action is started, and the vehicle will either warn, land, or return.
 
 The code can be found in `Navigator::check_traffic` ([/src/modules/navigator/navigator_main.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/navigator_main.cpp)).
+
+PX4 will also forward the transponder data to a GCS if this has been configured for the MAVLink instance (this is recommended).
+
+## Further Information
+
+* [MAVLink Peripherals](../peripherals/mavlink_peripherals.md)
+* [Serial Port Configuration](../peripherals/serial_configuration.md)

--- a/en/advanced_features/traffic_avoidance_adsb.md
+++ b/en/advanced_features/traffic_avoidance_adsb.md
@@ -1,0 +1,31 @@
+# Air Traffic Avoidance: ADS-B/FLARM
+
+PX4 uses [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast) and [FLARM](https://en.wikipedia.org/wiki/FLARM) transponders to support simple air traffic avoidance in [missions](../flight_modes/mission.md).
+If a potential collision is detected, PX4 can *warn*, immediately [land](../flight_modes/land.md), or [return](../flight_modes/return.md) - depending on the value of [NAV_TRAFF_AVOID](#NAV_TRAFF_AVOID).
+
+
+## Setup
+
+### Hardware Setup
+
+
+
+### Software Configuration (Parameters)
+
+
+<span id="NAV_TRAFF_AVOID"></span>[NAV_TRAFF_AVOID](../advanced_config/parameter_reference.md#NAV_TRAFF_AVOID) | Enable traffic avoidance mode specify avoidance response. 0: Disable, 1: Warn only, 2: Return mode, 3: Land mode.
+
+
+## Simulation/Testing
+
+
+
+## Implementation
+
+PX4 listens for valid transponder reports during missions.
+
+If a valid transponder report is received, PX4 first uses the transponder position and heading information to estimate whether the vehicles will share a similar altitude before they pass each other.
+If they may then PX4 it estimates how the closest distance between the path to the next waypoint and the other vehicles predicted path.
+If the crossing point is less that 500m for altitude and path distance (hard coded), the [Traffic Avoidance Failsafe](../config/safety.md#traffic_avoidance) action is started, and the vehicle will either warn, land, or return.
+
+The code can be found in `Navigator::check_traffic` ([/src/modules/navigator/navigator_main.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/navigator_main.cpp)).

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -210,7 +210,7 @@ Parameter | Description
 
 ### Traffic Avoidance Failsafe
 
-The Traffic Avoidance Failsafe allows PX4 to respond to transponder data (e.g. from ADSB transponders).
+The Traffic Avoidance Failsafe allows PX4 to respond to transponder data (e.g. from [ADSB transponders](../advanced_features/traffic_avoidance_adsb.md)) during missions.
 
 The relevant parameters are shown below:
 

--- a/en/peripherals/adsb_flarm.md
+++ b/en/peripherals/adsb_flarm.md
@@ -1,0 +1,5 @@
+# ADS-B/FLARM Receivers
+
+PX4 supports simple air traffic avoidance in [missions](../flight_modes/mission.md) using [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast) or [FLARM](https://en.wikipedia.org/wiki/FLARM) transponders that have a MAVLink interface (that emits the [ADSB_VEHICLE](https://mavlink.io/en/messages/common.html#ADSB_VEHICLE) message)).
+
+For more information on supported peripherals see [Air Traffic Avoidance: ADSB/FLARM](../advanced_features/traffic_avoidance_adsb.md#supported_hardware).

--- a/en/peripherals/mavlink_peripherals.md
+++ b/en/peripherals/mavlink_peripherals.md
@@ -1,11 +1,11 @@
 # MAVLink Peripherals (GCS/OSD/Companion)
 
-Ground Control Stations (GCS), On-Screen Displays (OSD), Companion Computers, and other MAVLink peripherals interact with PX4 using separate MAVLink streams, sent via different serial ports.
+Ground Control Stations (GCS), On-Screen Displays (OSD), Companion Computers, ADS-B receivers, and other MAVLink peripherals interact with PX4 using separate MAVLink streams, sent via different serial ports.
 These communication channels are configured using the [MAVLink parameters](../advanced_config/parameter_reference.md#mavlink).
 
 ## MAVLink Instances
 
-In order to assign a particular peripheral to a serial port we use the (abstract) concept of a *MAVLink instance*. 
+In order to assign a particular peripheral to a serial port we use the (abstract) concept of a *MAVLink instance*.
 Each instance can represent a particular set of streamed messages (see "mode" below); parameters are used to define the set of messages, the port used, data rate, etc.
 
 > **Note** At time of writing three instances are defined, which correspond to the 0, 1, 2 in the parameters listed below.


### PR DESCRIPTION
This adds ADSB/FLarm docs.

@julianoes There are some open questions, which I hope you can help me with. Specifically:
1. What hardware do we support for this purpose - ie:
   - is there a "generic" definition/protocol/type that people can use.
   - What specific types have we tested against, and where do we recommend people getting it from
2. What hardware setup is required. Ie what bus/port, and what parameters are needed? Do the boards come with appropriate connectors? 
3. How can this feature be simulated/tested?

Is there anything else that should be mentioned?
