### PR TITLE
Modify docs to note auto disarm is now the default

### DIFF
--- a/en/advanced_config/land_detector.md
+++ b/en/advanced_config/land_detector.md
@@ -5,9 +5,9 @@ This topic explains the main parameters you may wish to tune in order to improve
 
 ## Auto-Disarming
 
-The land-detector does not auto-disarm the system on landing.
+The land-detector automatically disarms the vehicle on landing.
 
-You can set [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) to specify the number of seconds after landing that the system should disarm (auto-disarming is disabled if this is zero).
+You can set [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) to specify the number of seconds after landing that the system should disarm (or turn off auto-disarming by setting the parameter to -1).
 
 ## Multicopter Configuration
 
@@ -42,7 +42,7 @@ These two parameters are sometimes worth tuning:
 
 ### Multicopter Land Detection
 
-In order to detect landing, the multicopter first has to go through three different states, where each state contains the conditions from the previous states plus tighter constraints. 
+In order to detect landing, the multicopter first has to go through three different states, where each state contains the conditions from the previous states plus tighter constraints.
 If a condition cannot be reached because of missing sensors, then the condition is true by default. 
 For instance, in [Acro mode](../flight_modes/acro_mc.md) and no sensor is active except for the gyro sensor, then the detection solely relies on thrust output and time. 
  

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -144,7 +144,7 @@ The settings and underlying parameters are shown below:
 
 Setting | Parameter | Description
 --- | --- | ---
-Disarm After | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Select checkbox to specify that the vehicle will disarm after landing, and enter delay after landing before disarming (must be non-zero).
+Disarm After | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Select checkbox to specify that the vehicle will disarm after landing, and enter delay after landing before disarming. The value must be non-zero but can be a fraction of a second.
 Landing Descent Rate | [MPC_LAND_SPEED](../advanced_config/parameter_reference.md#MPC_LAND_SPEED) | Rate of descent (MC only).
 
 

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -134,8 +134,9 @@ Loiter Time | [RTL_LAND_DELAY](../advanced_config/parameter_reference.md#RTL_LAN
 
 ### Land Mode Settings
 
-*Land at the current position* is a common [failsafe action](#failsafe_actions) that engages [Land Mode](../flight_modes/land.md). 
-This section shows how to set whether the vehicle will automatically disarm after landing. For Multicopters (only) you can additionally set the descent rate.
+*Land at the current position* is a common [failsafe action](#failsafe_actions) that engages [Land Mode](../flight_modes/land.md).
+This section shows how control when and if the vehicle automatically disarms after landing.
+For Multicopters (only) you can additionally set the descent rate.
 
 ![Safety - Land Mode Settings (QGC)](../../images/qgc/setup/safety_land_mode.png)
 
@@ -143,7 +144,7 @@ The settings and underlying parameters are shown below:
 
 Setting | Parameter | Description
 --- | --- | ---
-Disarm After | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Select checkbox to specify that the vehicle will disarm after landing, and enter delay after landing before disarming (must be non-zero). 
+Disarm After | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Select checkbox to specify that the vehicle will disarm after landing, and enter delay after landing before disarming (must be non-zero).
 Landing Descent Rate | [MPC_LAND_SPEED](../advanced_config/parameter_reference.md#MPC_LAND_SPEED) | Rate of descent (MC only).
 
 

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -135,7 +135,7 @@ Loiter Time | [RTL_LAND_DELAY](../advanced_config/parameter_reference.md#RTL_LAN
 ### Land Mode Settings
 
 *Land at the current position* is a common [failsafe action](#failsafe_actions) that engages [Land Mode](../flight_modes/land.md).
-This section shows how control when and if the vehicle automatically disarms after landing.
+This section shows how to control when and if the vehicle automatically disarms after landing.
 For Multicopters (only) you can additionally set the descent rate.
 
 ![Safety - Land Mode Settings (QGC)](../../images/qgc/setup/safety_land_mode.png)

--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -3,6 +3,7 @@
 [<img src="../../assets/site/position_fixed.svg" title="Position estimate required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
 The *Land* flight mode causes the vehicle to land at the position where the mode was engaged.
+After landing, vehicles will disarm after after a short timeout (by default).
 
 > **Note** 
 >  * This mode requires a valid position estimate unless the mode is entered due to a failsafe, in which case only altitude is required (typically a barometer is built into the flight controller).
@@ -13,27 +14,31 @@ The specific behaviour for each vehicle type is described below.
 
 ## Multi-Copter (MC)
 
-The vehicle will land at the location at which the mode was engaged. The vehicle descends at the rate specified in `MPC_LAND_SPEED` until it hits the ground.
+The vehicle will land at the location at which the mode was engaged.
+The vehicle descends at the rate specified in `MPC_LAND_SPEED` and will disarm after landing (by default).
 
 Landing is affected by the following parameters:
 
 Parameter | Description
 --- | ---
 [MPC_LAND_SPEED](../advanced_config/parameter_reference.md#MPC_LAND_SPEED) | The rate of descent during landing. This should be kept fairly low as the ground conditions are not known.
-[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Time-out for auto disarm after landing. By default this is 0 (vehicle will not auto-disarm after landing).
+[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Time-out for auto disarm after landing, in seconds. If set to -1 the vehicle will not disarm on landing.
 
 
 ## Fixed Wing (FW)
 
-The vehicle will turn and lands at the location at which the mode was engaged. Fixed wing landing logic and parameters are explained in the topic: [Landing (Fixed Wing)](../flying/fixed_wing_landing.md).
+The vehicle will turn and land at the location at which the mode was engaged.
+Fixed wing landing logic and parameters are explained in the topic: [Landing (Fixed Wing)](../flying/fixed_wing_landing.md).
 
-> **Note** Often a FW vehicle will follow a fixed landing trajectory to ground (it will not attempt a flared landing). This is because in LAND mode the vehicle may not know ground altitude and will assume it is at sea level. As ground level may be much higher, a vehicle will often reach the ground at an altitude above where flare logic would be engaged.
+> **Note** Often a FW vehicle will follow a fixed landing trajectory to ground (it will not attempt a flared landing).
+  This is because in LAND mode the vehicle may not know ground altitude and will assume it is at sea level.
+  As ground level may be much higher, a vehicle will often reach the ground at an altitude above where flare logic would be engaged.
 
 Landing is affected by the following parameters (also see [Landing (Fixed Wing)](../flying/fixed_wing_landing.md)):
 
 Parameter | Description
 --- | ---
-[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Time-out for auto disarm after landing. By default this is 0 (vehicle will not auto-disarm after landing).
+[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Time-out for auto disarm after landing, in seconds. If set to -1 the vehicle will not disarm on landing.
 
 ## VTOL
 

--- a/en/flight_modes/land.md
+++ b/en/flight_modes/land.md
@@ -3,7 +3,7 @@
 [<img src="../../assets/site/position_fixed.svg" title="Position estimate required (e.g. GPS)" width="30px" />](../getting_started/flight_modes.md#key_position_fixed)
 
 The *Land* flight mode causes the vehicle to land at the position where the mode was engaged.
-After landing, vehicles will disarm after after a short timeout (by default).
+After landing, vehicles will disarm after a short timeout (by default).
 
 > **Note** 
 >  * This mode requires a valid position estimate unless the mode is entered due to a failsafe, in which case only altitude is required (typically a barometer is built into the flight controller).

--- a/en/flying/basic_flying.md
+++ b/en/flying/basic_flying.md
@@ -24,7 +24,7 @@ Alternatively arming and disarming can also be performed in *QGroundControl* (PX
 
 The easiest way to takeoff is to use the automatic [Takeoff mode](../flight_modes/takeoff.md) (remembering that you need to arm the vehicle before you can engage the vehicle motors).
 
-Multicopter (and VTOL in multicopter mode) pilots can take off *manually* by enabling [position mode](../flight_modes/README.md#position_fw), arming the vehicle, and then raising the throttle stick above 62.5%. 
+Multicopter (and VTOL in multicopter mode) pilots can take off *manually* by enabling [position mode](../flight_modes/README.md#position_mc), arming the vehicle, and then raising the throttle stick above 62.5%. 
 Above this value all controllers are enabled and the vehicle goes to the throttle level required for hovering ([MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
 
 > **Tip** The automatic takeoff mode is highly recommended, in particular for Fixed Wing vehicles.

--- a/en/flying/basic_flying.md
+++ b/en/flying/basic_flying.md
@@ -19,22 +19,27 @@ This will start the propellers on a multicopter.
 To disarm, put the throttle stick in the bottom left corner.
 Alternatively arming and disarming can also be performed in *QGroundControl* (PX4 does not require a radio control for flying autonomously).
 
-
-## Takeoff and Landing
+<span id="takeoff-and-landing"></span>
+## Takeoff
 
 The easiest way to takeoff is to use the automatic [Takeoff mode](../flight_modes/takeoff.md) (remembering that you need to arm the vehicle before you can engage the vehicle motors).
-To land again automatically you can use [Land](../flight_modes/land.md) or [Return](../flight_modes/return.md) modes.
 
-> **Tip** The automatic takeoff/landing modes are highly recommended, in particular for Fixed Wing vehicles. 
+Multicopter (and VTOL in multicopter mode) pilots can take off *manually* by enabling [position mode](../flight_modes/README.md#position_fw), arming the vehicle, and then raising the throttle stick above 62.5%. 
+Above this value all controllers are enabled and the vehicle goes to the throttle level required for hovering ([MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
 
-For multicopter (and VTOL in multicopter mode) pilots can:
+> **Tip** The automatic takeoff mode is highly recommended, in particular for Fixed Wing vehicles.
 
-* Take off manually by enabling [position mode](../flight_modes/README.md#position_fw), arming the vehicle, and then raising the throttle stick above 62.5%. 
-  Above this value all controllers are enabled and the vehicle goes to the throttle level required for hovering ([MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
-* Land manually by pressing the throttle stick down until the vehicle lands and disarms (or set [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) > 0 to disarm automatically on landing).
+
+## Landing
+
+The easiest way to land is to use the automatic [Land](../flight_modes/land.md) or [Return](../flight_modes/return.md) modes.
+
+For multicopter (and VTOL in multicopter mode) pilots can land manually by pressing the throttle stick down until the vehicle lands and disarms (set [COM_DISARM_LAND<0](../advanced_config/parameter_reference.md#COM_DISARM_LAND) to disable auto-disarm on landing).
 
 > **Note** If you see the vehicle "twitch" during landing (turn down the motors, and then immediately turn them back up) this is probably caused by a poor [Land Detector Configuration](../advanced_config/land_detector.md) (specifically, a poorly set [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
 
+<span></span>
+> **Tip** Automatic landing is highly recommended, in particular for Fixed Wing vehicles. 
 
 ## Flight Controls/Commands
 
@@ -85,5 +90,4 @@ The following three modes are highly recommended for new users:
 * Position - When sticks are released the vehicle will stop (and hold position against wind drift)
 
 > **Tip** You can also access automatic modes through the buttons on the bottom of the *QGroundControl* main flight screen.
-
 


### PR DESCRIPTION
This also splits the getting started level takeoff and landing docs into separate headings.

Fyi @MaEtUgR - does this look OK?