### PR TITLE
Deprecate aero

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -190,13 +190,13 @@
   * [OcPoC-Zynq Mini](flight_controller/ocpoc_zynq.md)
   * [BeagleBone Blue](flight_controller/beaglebone_blue.md)
 * [Complete Vehicles](complete_vehicles/README.md)
-  * [Intel® Aero Ready to Fly Drone](complete_vehicles/intel_aero.md)
   * [Crazyflie 2.0](complete_vehicles/crazyflie2.md)
   * [Parrot Bebop](complete_vehicles/bebop.md)
   * [MindRacer BNF & RTF](complete_vehicles/mindracer_BNF_RTF.md)
     * [MindRacer 210](complete_vehicles/mindracer210.md)
     * [NanoMind 110](complete_vehicles/nanomind110.md)
   * [BetaFPV Beta75X 2S Brushless Whoop](complete_vehicles/betafpv_beta75x.md)
+  * [Intel® Aero RTF Drone (Discontinued)](complete_vehicles/intel_aero.md)
 * [Development](development/development.md)
 
 

--- a/en/complete_vehicles/README.md
+++ b/en/complete_vehicles/README.md
@@ -14,8 +14,7 @@ This section contains information about complete vehicles that run PX4.
   * [Crazyflie 2.0](../complete_vehicles/crazyflie2.md)
   * [Parrot Bebop](../complete_vehicles/bebop.md)
   * [BetaFPV Beta75X 2S Brushless Whoop](../complete_vehicles/betafpv_beta75x.md)
-- Whole-vehicle hardware reference platforms that use PX4:
-  * [Intel® Aero Ready to Fly Drone](../complete_vehicles/intel_aero.md) - UAV development platform with autopilot and integrated onboard computer.
+<!--  Whole-vehicle hardware reference platforms that use PX4: -->
 - Consumer drones run a custom version of PX4 (supported by their vendors):
   * Multicopter
     * [Yuneec Typhoon H Plus](https://us.yuneec.com/typhoon-h-plus)

--- a/en/complete_vehicles/intel_aero.md
+++ b/en/complete_vehicles/intel_aero.md
@@ -1,6 +1,9 @@
 # Intel Aero Ready to Fly Drone
 
-The [Intel Aero Ready to Fly Drone](https://software.intel.com/en-us/aero/drone-dev-kit)® is a UAV development platform. 
+> **Warning** The *Intel Aero* has been discontinued, and is no longer being supported.
+  The PX4 port is therefore deprecated, and will be removed from the codelines in future releases.
+
+The *Intel Aero Ready to Fly Drone*® is a UAV development platform.
 Part of this is the [Intel Aero Compute Board](https://software.intel.com/en-us/aero/dev-kit), running Linux on a Quad-core CPU. 
 The other part is an STM32 microcontroller that is connected to it and that runs PX4 on NuttX. 
 These are integrated in the same package on the *Intel Aero Ready to Fly Drone*, 

--- a/en/flight_controller/pixhawk_series.md
+++ b/en/flight_controller/pixhawk_series.md
@@ -5,7 +5,7 @@
 
 Manufacturers have created many different boards based on the open designs, with form factors that are optimised for applications from cargo carrying though to first person view (FPV) racers.
 
-> **Tip** For computationally intensive tasks (e.g. computer vision) you will need a separate companion computer (e.g. [Raspberry Pi 2/3 Navio2](../flight_controller/raspberry_pi_navio2.md)) or a platform with an integrated companion solution (e.g. [Intel® Aero Ready to Fly Drone](../complete_vehicles/intel_aero.md), [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md)).
+> **Tip** For computationally intensive tasks (e.g. computer vision) you will need a separate companion computer (e.g. [Raspberry Pi 2/3 Navio2](../flight_controller/raspberry_pi_navio2.md)) or a platform with an integrated companion solution (e.g. [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md)).
 
 
 ## Key Benefits

--- a/en/getting_started/flight_controller_selection.md
+++ b/en/getting_started/flight_controller_selection.md
@@ -28,7 +28,6 @@ These flight controllers (and development platforms) offer on-vehicle "companion
 Controller | Description
 --- | ---
 [Qualcomm Snapdragon Flight](../flight_controller/snapdragon_flight.md) | A high-end autopilot computer that runs PX4 on the DSP (on QuRT RTOS). It includes a camera and WiFi.
-[Intel® Aero Ready to Fly Drone](../complete_vehicles/intel_aero.md) | A UAS development platform that integrates a Linux computer, PX4 on NuttX, and a camera in a single package.
 [Raspberry Pi 2/3 Navio2](../flight_controller/raspberry_pi_navio2.md) | RaPi can be connected to an autopilot and used as a companion computer.
 
 

--- a/en/sensor/leddar_one.md
+++ b/en/sensor/leddar_one.md
@@ -32,10 +32,6 @@ There is no need to set the baud rate for the port, as this is configured by the
   drivers/distance_sensor/leddar_one
   ```
 
-## Intel Aero {#aero}
-
-The LeddarOne is the recommended rangefinder for the *Intel® Aero Ready to Fly Drone*. For more information on hardware setup and configuration see: [The Intel® Aero Ready to Fly Drone](../complete_vehicles/intel_aero.md#leddarone).
-
 
 ## Further Information
 


### PR DESCRIPTION
Fixes #529 

This deprecates Aero. It is no longer being supported, so this marks the main doc and sidebar as being discontinued. Links to the doc have largely been removed.