### PR TITLE
Offboard: Clarify mode not automatic

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -7,7 +7,7 @@ The setpoint may be provided by a MAVLink API (e.g. [MAVSDK](https://mavsdk.mav
 
 > **Note**
 >  * This mode requires position or pose/attitude information - e.g. GPS, optical flow, visual-inertial odometry, mocap, etc.
->  * This mode is automatic (RC control is disabled [by default](../advanced_config/parameter_reference.md#COM_RC_OVERRIDE) except to change modes).
+>  * RC control is disabled except to change modes.
 >  * The vehicle must be armed before this mode can be engaged.
 >  * The vehicle must be already be receiving a stream of target setpoints before this mode can be engaged.
 >  * The vehicle will exit the mode if target setpoints are not received at a rate of > 2Hz.


### PR DESCRIPTION
As discussed in https://github.com/PX4/Devguide/issues/843#issuecomment-514178232, offboard is not an automatic mode and experimentation shows that setting COM_RC_OVERRIDE does not enable RC sticks.

@mhkabir @MaEtUgR Can you please both sanity check this. 