### PR TITLE
Camera Triggering: Trigger pins use direct pin access

### DIFF
--- a/en/peripherals/camera.md
+++ b/en/peripherals/camera.md
@@ -24,7 +24,7 @@ You can choose which pins to use for triggering using the [TRIG_PINS](../advance
 The default is 56, which means that trigger is enabled on *FMU* pins 5 and 6.
 
 > **Note** On a Pixhawk flight controller that has both FMU and I/O boards these FMU pins map to `AUX5` and `AUX6` (e.g. Pixhawk 4, CUAV v5+). 
-  On a controller that only has an FMU, the pins map to `MAIN4` and `MAIN6` (e.g. Pixhawk 4 mini, CUAV v5 nano).
+  On a controller that only has an FMU, the pins map to `MAIN5` and `MAIN6` (e.g. Pixhawk 4 mini, CUAV v5 nano).
   At time of writing triggering only works on FMU pins - you can't trigger a camera using pins on the I/O board.
 
 <span></span>

--- a/en/peripherals/camera.md
+++ b/en/peripherals/camera.md
@@ -20,8 +20,14 @@ Mode | Description
 
 ## Trigger Hardware Configuration
 
-You can choose which AUX pins to use for triggering using the [TRIG_PINS](../advanced_config/parameter_reference.md#TRIG_PINS) parameter. The default is 56, which means that trigger is enabled on AUX 5 and AUX 6. 
+You can choose which pins to use for triggering using the [TRIG_PINS](../advanced_config/parameter_reference.md#TRIG_PINS) parameter.
+The default is 56, which means that trigger is enabled on *FMU* pins 5 and 6.
 
+> **Note** On a Pixhawk flight controller that has both FMU and I/O boards these FMU pins map to `AUX5` and `AUX6` (e.g. Pixhawk 4, CUAV v5+). 
+  On a controller that only has an FMU, the pins map to `MAIN4` and `MAIN6` (e.g. Pixhawk 4 mini, CUAV v5 nano).
+  At time of writing triggering only works on FMU pins - you can't trigger a camera using pins on the I/O board.
+
+<span></span>
 > **Warning** With `TRIG_PINS` set to its **default** value of 56, you can use the AUX pins 1, 2, 3 and 4 as actuator outputs (for servos/ESCs). Due to the way the hardware timers are handled (1234 and 56 are 2 different groups handled by 2 timers), this is the ONLY combination which allows the simultaneous usage of camera trigger and FMU actuator outputs. **DO NOT CHANGE THE DEFAULT VALUE OF `TRIG_PINS` IF YOU NEED ACTUATOR OUTPUTS.**
 
 ## Trigger Interface Backends


### PR DESCRIPTION
Clarify that camera triggering off FMU only, and how the mapping works in FCs with/without I/O board.

Follows from https://github.com/PX4/Devguide/pull/852#issuecomment-521628887