### PR TITLE
Add documentation on prearm

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -122,6 +122,8 @@
   * [Sensor Thermal Compensation](advanced_config/sensor_thermal_calibration.md)
   * [Advanced Controller Orientation](advanced_config/advanced_flight_controller_orientation_leveling.md)
   * [Static Pressure Buildup](advanced_config/static_pressure_buildup.md)
+  * [Prearm/Arm/Disarm Configuration](advanced_config/prearm_arm_disarm.md)
+  prearm_arm_disarm.md
   * [Full Parameter Reference](advanced_config/parameter_reference.md)
 * [Peripheral Hardware](peripherals/README.md)
   * [Serial Port Configuration](peripherals/serial_configuration.md)

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -81,7 +81,6 @@ The startup sequence is:
 ### COM_PREARM_MODE=Safety or Disabled and No Safety Switch
 
 With no safety switch, when `COM_PREARM_MODE` is set to *Safety* or *Disabled* prearm mode cannot be enabled (same as disarmed). 
-Arm to activate all actuators.
 This corresponds to [COM_PREARM_MODE=0 or 1](#COM_PREARM_MODE) (Disabled/Safety Switch) and [CBRK_IO_SAFETY=22027](#CBRK_IO_SAFETY) (I/O safety circuit breaker engaged).
 
 The startup sequence is:

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -1,0 +1,135 @@
+# Prearm, Arm, Disarm Configuration
+
+Vehicles may have moving parts, some of which are potentially dangerous when powered (in particular motors and propellers)!
+
+To reduce the chance of accidents, PX4 has explicit state(s) for powering the vehicle components:
+- **Disarmed:** There is no power to motors or actuators.
+- **Pre-armed:** Actuators and other non-dangerous electronics are powered.
+  - In this state you can move ailerons, flaps etc, but motors/propellers are locked.
+- **Armed:** Vehicle is fully powered, including motors/propellers.
+
+A [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) (if available) is used as a precondition for arming the vehicle, and may also be used to enable the pre-armed state. When permitted, arming is enabled using an arming sequence, switch or MAVLink command. 
+
+PX4 allows you to configure how prearming, arming and disarming work using parameters (which can be edited in *QGroundControl* via the [parameter editor](../advanced_config/parameters.md)), as described in the following sections.
+
+## Arming Sequence: Pre Arm Mode & Safety Button
+
+The arming sequence depends on whether or not there is a *safety switch*, and is controlled by the parameters [COM_PREARM_MODE](#COM_PREARM_MODE) (Prearm mode) and [CBRK_IO_SAFETY](#CBRK_IO_SAFETY) (I/O safety circuit breaker).
+
+The [COM_PREARM_MODE](#COM_PREARM_MODE) parameter defines when/if pre-arm mode is enabled ("safe"/non-throttling actuators are able to move):
+- *Disabled*: There is no separate pre-arm mode where only "safe"/non-throttling actuators are enabled.
+- *Safety Switch* (Default): The pre-arm mode is enabled by the safety switch. 
+  If there is no safety switch then pre-arm mode will not be enabled.
+- *Always*: Prearm mode is enabled from power up. 
+
+If there is a safety switch then this will be a precondition for arming.
+If there is no safety switch the I/O safety circuit breaker must be engaged ([CBRK_IO_SAFETY](#CBRK_IO_SAFETY)), and arming will depend only on the arm command.
+
+The sections below explain the startup sequences for the different configurations
+
+
+### Default: COM_PREARM_MODE=Safety and Safety Switch
+
+The default configuration uses safety switch to prearm.
+From prearm you can then arm to engage all motors/actuators.
+It corresponds to: [COM_PREARM_MODE=1](#COM_PREARM_MODE) (safety switch) and [CBRK_IO_SAFETY=0](#CBRK_IO_SAFETY) (I/O safety circuit breaker disabled).
+
+The default startup sequence is:
+1. Power-up.
+   - All actuators locked into disarmed position
+   - Not possible to arm.
+1. Safety switch is pressed.
+   - System now prearmed: non-throttling actuators can move (e.g. ailerons).
+   - System safety is off: Arming possible.
+1. Arm command is issued.
+   - The system is armed.
+   - All motors and actuators can move.
+   
+### COM_PREARM_MODE=Disabled and Safety Switch
+
+When prearm mode is *Disabled*, engaging the safety switch does not unlock the "safe" actuators, though it does allow you to then arm the vehicle.
+This corresponds to [COM_PREARM_MODE=0](#COM_PREARM_MODE) (Disabled) and [CBRK_IO_SAFETY=0](#CBRK_IO_SAFETY) (I/O safety circuit breaker disabled).
+
+The startup sequence is:
+1. Power-up.
+   - All actuators locked into disarmed position
+   - Not possible to arm.
+1. Safety switch is pressed.
+   - *All actuators stay locked into disarmed position (same as disarmed).*
+   - System safety is off: Arming possible.
+1. Arm command is issued.
+   - The system is armed.
+   - All motors and actuators can move.
+   
+### COM_PREARM_MODE=Always and Safety Switch
+
+When prearm mode is *Always*, prearm mode is enabled from power up.
+To arm, you still need the safety switch. 
+This corresponds to [COM_PREARM_MODE=2](#COM_PREARM_MODE) (Always) and [CBRK_IO_SAFETY=0](#CBRK_IO_SAFETY) (I/O safety circuit breaker disabled).
+
+The startup sequence is:
+1. Power-up.
+   - System now prearmed: non-throttling actuators can move (e.g. ailerons).
+   - Not possible to arm.
+1. Safety switch is pressed.
+   - System safety is off: Arming possible.
+1. Arm command is issued.
+   - The system is armed.
+   - All motors and actuators can move.
+
+
+### COM_PREARM_MODE=Safety or Disabled and No Safety Switch
+
+With no safety switch, when `COM_PREARM_MODE` is set to *Safety* or *Disabled* prearm mode cannot not enabled (same as disarmed). 
+Arm to activate all actuators.
+This corresponds to [COM_PREARM_MODE=0 or 1](#COM_PREARM_MODE) (Disabled/Safety Switch) and [CBRK_IO_SAFETY=22027](#CBRK_IO_SAFETY) (I/O safety circuit breaker engaged).
+
+The startup sequence is:
+1. Power-up.
+   - All actuators locked into disarmed position
+   - System safety is off: Arming possible.
+1. Arm command is issued.
+   - The system is armed.
+   - All motors and actuators can move.
+
+
+### COM_PREARM_MODE=Always and No Safety Switch
+
+When prearm mode is *Always*, prearm mode is enabled from power up.
+This corresponds to [COM_PREARM_MODE=2](#COM_PREARM_MODE) (Always) and [CBRK_IO_SAFETY=22027](#CBRK_IO_SAFETY) (I/O safety circuit breaker engaged).
+
+The startup sequence is:
+1. Power-up.
+   - System now prearmed: non-throttling actuators can move (e.g. ailerons).
+   - System safety is off: Arming possible.
+1. Arm command is issued.
+   - The system is armed.
+   - All motors and actuators can move.
+
+
+
+### Parameters
+
+Parameter | Description
+--- | ---
+<span id="COM_PREARM_MODE"></span>[COM_PREARM_MODE](../advanced_config/parameter_reference.md#COM_PREARM_MODE) | Condition to enter prearmed mode. `0`: Disabled, `1`: Safety switch (prearm mode enabled by safety switch; if no switch present cannot be enabled), `2`: Always (prearm mode enabled from power up). Default: `1` (safety button).
+<span id="CBRK_IO_SAFETY"></span>[CBRK_IO_SAFETY](../advanced_config/parameter_reference.md#CBRK_IO_SAFETY) | Circuit breaker for IO safety.
+
+
+
+## Auto-Disarming
+
+By default vehicles will automatically disarm on landing, or if you take too long to take off after arming.
+The feature is configured using the following timeouts.
+
+Parameter | Description
+--- | ---
+<span id="COM_DISARM_LAND"></span>[COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) | Time-out for auto disarm after landing. Default: 2s (-1 to disable).
+<span id="COM_DISARM_PRFLT"></span>[COM_DISARM_PRFLT](../advanced_config/parameter_reference.md#COM_DISARM_PRFLT) | Time-out for auto disarm if too slow to takeoff. Default: 10s (<=0 to disable).
+
+
+
+<!-- Discussion:
+https://github.com/PX4/Firmware/pull/12806#discussion_r318337567 
+https://github.com/PX4/px4_user_guide/issues/567#issue-486653048
+-->

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -80,7 +80,7 @@ The startup sequence is:
 
 ### COM_PREARM_MODE=Safety or Disabled and No Safety Switch
 
-With no safety switch, when `COM_PREARM_MODE` is set to *Safety* or *Disabled* prearm mode cannot not enabled (same as disarmed). 
+With no safety switch, when `COM_PREARM_MODE` is set to *Safety* or *Disabled* prearm mode cannot be enabled (same as disarmed). 
 Arm to activate all actuators.
 This corresponds to [COM_PREARM_MODE=0 or 1](#COM_PREARM_MODE) (Disabled/Safety Switch) and [CBRK_IO_SAFETY=22027](#CBRK_IO_SAFETY) (I/O safety circuit breaker engaged).
 

--- a/en/flying/basic_flying.md
+++ b/en/flying/basic_flying.md
@@ -5,24 +5,28 @@ This topic explains the basics of flying a vehicle using an [RC Transmitter](../
 > **Note** Before you fly for the first time you should read our [First Flight Guidelines](../flying/first_flight_guidelines.md).
 
 
-## Arm the Vehicle
+## Arm the Vehicle {#arm}
 
-Before you can fly the vehicle it must first be *armed* (this will start the propellers rotating).
+Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming).
+This will power all motors and actuators; on a multicopter it will start propellers turning.
 
+To arm the drone:
+- First disengage the [safety switch](../getting_started/px4_basic_concepts.md#safety_switch).
+- Use the arm command for your vehicle - put the throttle stick in the bottom right corner.
+  - Alternatively configure an [arm/disarm switch](../config/safety.md#arming_switch).
+  - You can also arm in *QGroundControl* (PX4 does not require a radio control for flying autonomously).
 
-> **Tip** The vehicle will not arm until it is [calibrated/configured](../config/README.md) and have a position lock. 
+> **Tip** The vehicle will not arm until it is [calibrated/configured](../config/README.md) and has a position lock.
   [Vehicle Status Notifications](../getting_started/vehicle_status.md) (including on-vehicle LEDs, audio notifications and *QGroundControl* updates) can tell you when the vehicle is ready to fly (and help you work out the cause when it is not ready to fly).
 
-To arm the drone, put the throttle stick in the bottom right corner.
-This will start the propellers on a multicopter.
-
-To disarm, put the throttle stick in the bottom left corner.
-Alternatively arming and disarming can also be performed in *QGroundControl* (PX4 does not require a radio control for flying autonomously).
+<span></span>
+> **Note** The vehicle will (by [default](../advanced_config/parameter_reference.md#COM_DISARM_PRFLT)) automatically [disarm](#disarm) if you take too long to take off!
+  This is a safety measure to ensure that vehicles return to a safe state when not in use.
 
 <span id="takeoff-and-landing"></span>
 ## Takeoff
 
-The easiest way to takeoff is to use the automatic [Takeoff mode](../flight_modes/takeoff.md) (remembering that you need to arm the vehicle before you can engage the vehicle motors).
+The easiest way to takeoff is to use the automatic [Takeoff mode](../flight_modes/takeoff.md) (remembering that you need to [arm the vehicle](#arm) before you can engage the vehicle motors).
 
 Multicopter (and VTOL in multicopter mode) pilots can take off *manually* by enabling [position mode](../flight_modes/README.md#position_mc), arming the vehicle, and then raising the throttle stick above 62.5%. 
 Above this value all controllers are enabled and the vehicle goes to the throttle level required for hovering ([MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
@@ -38,12 +42,18 @@ Above this value all controllers are enabled and the vehicle goes to the throttl
 
 The easiest way to land is to use the automatic [Land](../flight_modes/land.md) or [Return](../flight_modes/return.md) modes.
 
-For multicopter (and VTOL in multicopter mode) pilots can land manually by pressing the throttle stick down until the vehicle lands and disarms (set [COM_DISARM_LAND<0](../advanced_config/parameter_reference.md#COM_DISARM_LAND) to disable auto-disarm on landing).
+For multicopter (and VTOL in multicopter mode) pilots can land manually by pressing the throttle stick down until the vehicle lands and disarms.
+
+Note that vehicles automatically disarm on landing by default:
+- Use [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_DISARM_LAND) to set the time to auto-disarm after landing (or disable it altogether).
+- Manually disarm by putting the throttle stick in the bottom left corner.
 
 > **Note** If you see the vehicle "twitch" during landing (turn down the motors, and then immediately turn them back up) this is probably caused by a poor [Land Detector Configuration](../advanced_config/land_detector.md) (specifically, a poorly set [MPC_THR_HOVER](../advanced_config/parameter_reference.md#MPC_THR_HOVER)).
 
 <span></span>
-> **Tip** Automatic landing is highly recommended, in particular for Fixed Wing vehicles. 
+> **Tip** Automatic landing is highly recommended, in particular for Fixed Wing vehicles.
+
+
 
 ## Flight Controls/Commands
 

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -139,8 +139,8 @@ To reduce the chance of accidents, PX4 has explicit state(s) for powering the ve
   - In this state you can move ailerons, flaps etc, but motors/propellers are locked.
 - **Armed:** Vehicle is fully powered, including motors/propellers.
 
-A [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) (if available) is used as a precondition for arming the vehicle, and may also be used to enable the pre-armed state.
-When permitted, arming is enabled using an arming sequence, switch or MAVLink command. 
+By default, a [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) is used to enter the pre-armed state.
+Arming is then enabled using an arming sequence, switch or MAVLink command. 
 
 The vehicle is initially disarmed, and must be armed before flight; if you don't take off quickly enough it will automatically disarm (returning the vehicle to a safe state).
 Similarly, when you land the vehicle will usually automatically disarm so that it can be approached safely.

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -95,6 +95,14 @@ Some RC systems can additionally receive telemetry information back from the aut
 * [FrSky Telemetry](../peripherals/frsky_telemetry.md) - Set up the RC transmitter to receive telemetry/status updates from PX4.
 
 
+## Safety Switch {#safety_switch}
+
+It is common for vehicles to have a *safety switch* that must be engaged before the vehicle can be [armed](#arming) (when armed, motors are powered and propellers can turn).
+Commonly the safety switch is integrated into a GPS unit, but it may also be a separate physical component.
+
+> **Note** A vehicle that is armed is potentially dangerous.
+  The safety switch is an additional mechanism that prevents arming from happening by accident.
+
 ## Data/Telemetry Radios
 
 [Data/Telemetry Radios](../telemetry/README.md) can provide a wireless MAVLink connection between a ground control station like *QGroundControl* and a vehicle running PX4. 
@@ -119,6 +127,26 @@ PX4 uses SD memory cards for storing [flight logs](../getting_started/flight_rep
 > **Tip** The maximum supported SD card size on Pixhawk boards is 32GB.
 
 A number of recommended cards are listed in: [Developer Guide > Logging](http://dev.px4.io/en/log/logging.html#sd-cards)
+
+
+## Disarmed/Pre-armed/Armed {#arming}
+
+Vehicles may have moving parts, some of which are potentially dangerous when powered (in particular motors and propellers)!
+
+To reduce the chance of accidents, PX4 has explicit state(s) for powering the vehicle components:
+- **Disarmed:** There is no power to motors or actuators.
+- **Pre-armed:** Actuators and other non-dangerous electronics are powered.
+  - In this state you can move ailerons, flaps etc, but motors/propellers are locked.
+- **Armed:** Vehicle is fully powered, including motors/propellers.
+
+A [safety switch](../getting_started/px4_basic_concepts.md#safety_switch) (if available) is used as a precondition for arming the vehicle, and may also be used to enable the pre-armed state.
+When permitted, arming is enabled using an arming sequence, switch or MAVLink command. 
+
+The vehicle is initially disarmed, and must be armed before flight; if you don't take off quickly enough it will automatically disarm (returning the vehicle to a safe state).
+Similarly, when you land the vehicle will usually automatically disarm so that it can be approached safely.
+
+> **Note** The arming behaviour can be [configured](../advanced_config/prearm_arm_disarm.md) (e.g. the time until vehicle automatically disarms after landing).
+
 
 
 ## Flight Modes {#flight_modes}


### PR DESCRIPTION
Fix #567

This adds a new advanced configuration page for arming, prearming, disarming covering associated topics, including the prearm mode.

Otherwise is does some general fixes to other pages that refer to arming (or should!) and cross links. 