### PR TITLE
Make it easier to work out why parameters are missing

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -97,7 +97,7 @@
   * [Collision Prevention](computer_vision/collision_prevention.md)
   * [Path Planning Interface](computer_vision/path_planning_interface.md)
 * [Advanced Configuration](advanced_config/README.md)
-  * [Parameters](advanced_config/parameters.md)
+  * [Finding/Updating Parameters](advanced_config/parameters.md)
   * [Multicopter Config/Tuning](config_mc/README.md)
     * [MC PID Tuning Guide](config_mc/pid_tuning_guide_multicopter.md)
     * [MC Setpoint Tuning (Trajectory Generator)](config_mc/mc_trajectory_tuning.md)

--- a/en/advanced_config/parameters.md
+++ b/en/advanced_config/parameters.md
@@ -1,18 +1,21 @@
-# Parameter Configuration
+# Finding/Updating Parameters
 
-A lot of PX4 behaviour can be configured/tuned using [parameters](../advanced_config/parameter_reference.md) (e.g. [Multicopter PID gains](../config_mc/pid_tuning_guide_multicopter.md), calibration information, etc.).
+PX4 behaviour can be configured/tuned using [parameters](../advanced_config/parameter_reference.md) (e.g. [Multicopter PID gains](../config_mc/pid_tuning_guide_multicopter.md), calibration information, etc.).
 
-The *QGroundControl Parameters screen* allows you to find and modify **any** of the parameters associated with the vehicle. The screen is accessed by clicking the top menu *Gear* icon and then *Parameters* in the sidebar.
+The *QGroundControl Parameters* screen allows you to find and modify **any** of the parameters associated with the vehicle.
+The screen is accessed by clicking the top menu *Gear* icon and then *Parameters* in the sidebar.
 
-> **Note** The Parameters screen is needed when accessing less commonly modified parameters - for example while tuning a new vehicle. Most of the more commonly used parameters are more conveniently set using the dedicated setup screens described in the [Basic Configuration](../config/README.md) section.
+> **Note** Most of the more commonly used parameters are more conveniently set using the dedicated setup screens described in the [Basic Configuration](../config/README.md) section.
+  The *Parameters* screen is needed when modifying less commonly modified parameters - for example while tuning a new vehicle.
 
 <span></span>
-> **Note** While some parameters can be changed in flight, this is not recommended (except where explicitly stated in the guide).
+> **Warning** While some parameters can be changed in flight, this is not recommended (except where explicitly stated in the guide).
 
 
-## Finding a Parameter
+## Finding a Parameter {#finding}
 
-You can search for a parameter by entering a term in the *Search* field. This will show you a list of all parameter names and descriptions that contain the entered substring (press **Clear** to reset the search).
+You can search for a parameter by entering a term in the *Search* field.
+This will show you a list of all parameter names and descriptions that contain the entered substring (press **Clear** to reset the search).
 
 ![Parameters Search](../../images/qgc/setup/parameters_search.jpg)
 
@@ -20,14 +23,56 @@ You can also browse the parameters by group by clicking on the buttons to the le
 
 ![Parameters Screen](../../images/qgc/setup/parameters_px4.jpg)
 
+> **Tip** If you can't find an expected parameter, see the [next section](#missing).
 
-## Changing a Parameter
 
-To change the value of a parameter click on the parameter row in a group or search list. This will open a side dialog in which you can update the value (this dialog also provides additional detailed information about the parameter - including whether a reboot is required for the change to take effect). 
+## Missing Parameters {#missing}
+
+Parameters are usually not visible because either they are conditional on other parameters, or they are not present in the firmware (see below).
+
+### Conditional Parameters
+
+A parameter may not be displayed if it is conditional on another parameter that is not enabled.
+
+You can usually find out what parameters are conditional by searching the [full parameter reference](../advanced_config/parameter_reference.md) and other documentation.
+In particular [serial port configuration parameters](../peripherals/serial_configuration.md) depend on what service is assigned to a serial port.
+
+
+### Parameter Not In Firmware
+
+A parameter may not be present in the firmware because you're using a different version of PX4 or because you're using a build in which the associated module is not included.
+
+New parameters are added in each PX4 version, and existing parameters are sometimes removed or renamed.
+You can check whether a parameter *should* be present by reviewing the [full parameter reference](../advanced_config/parameter_reference.md) for the version you're targeting.
+You can also search for the parameter in the source tree and in the release notes.
+
+The other reason that a parameter might not be in firmware is if its associated module has not been included.
+This is a problem (in particular) for *FMUv2 firmware*, which omits many modules so that PX4 can fit into the 1MB of available flash.
+There are two options to solve this problem:
+- Check if you can update your board to run FMUv3 firmware, which includes all modules: [Firmware > FMUv2 Bootloader Update](../config/firmware.md#bootloader)
+- If your board can only run FMUv2 firmware you will need to [rebuild PX4](https://dev.px4.io/master/en/setup/building_px4.html) with the missing modules enabled.
+  You can see these commented out in [boards/px4/fmu-v2/default.cmake](https://github.com/PX4/Firmware/blob/master/boards/px4/fmu-v2/default.cmake):
+  ```
+  	DRIVERS
+		adc
+		#barometer # all available barometer drivers
+		barometer/ms5611
+		#batt_smbus
+		#camera_capture
+  ```
+  > **Note** You may also need to disable other modules in order to fit the rebuilt firmware into 1MB flash.
+    Finding modules to remove requires some trial/error and depends on what use cases you need the vehicle to meet.
+
+
+## Changing a Parameter {#changing}
+
+To change the value of a parameter click on the parameter row in a group or search list.
+This will open a side dialog in which you can update the value (this dialog also provides additional detailed information about the parameter - including whether a reboot is required for the change to take effect).
 
 ![Changing a parameter value](../../images/qgc/setup/parameters_changing.png)
 
-> **Note** When you click **Save** the parameter is automatically and silently uploaded to the connected vehicle. Depending on the parameter, you may then need to reboot the flight controller for the change to take effect.
+> **Note** When you click **Save** the parameter is automatically and silently uploaded to the connected vehicle.
+  Depending on the parameter, you may then need to reboot the flight controller for the change to take effect.
 
 
 ## Tools
@@ -47,7 +92,8 @@ You can select additional options from the **Tools** menu on the top right hand 
 <br>Load parameters from an existing file or save your current parameter settings to a file.
 
 **Clear RC to Param**
-<br>This clears all associations between RC transmitter controls and parameters. For more information see: [Radio Setup > Param Tuning Channels](../config/radio.md#param-tuning-channels).
+<br>This clears all associations between RC transmitter controls and parameters.
+For more information see: [Radio Setup > Param Tuning Channels](../config/radio.md#param-tuning-channels).
 
 **Reboot Vehicle**
 <br>Reboot the vehicle (required after changing some parameters).

--- a/en/flight_controller/pixhawk_series.md
+++ b/en/flight_controller/pixhawk_series.md
@@ -19,9 +19,9 @@ Key benefits of using a *Pixhawk series* controller include:
 * Automated update of latest firmware via *QGroundControl* (end-user friendly).
 
 
-## Recommended Boards
+## Recommended Boards {#recommended}
 
-The following products in the series are recommended/regularly tested with PX4:
+The following products in the series are regularly tested with PX4:
 
 * [mRo Pixhawk](../flight_controller/mro_pixhawk.md)
 * [HKPilot32](../flight_controller/HKPilot32.md)
@@ -37,7 +37,8 @@ The following products in the series are recommended/regularly tested with PX4:
 * [V5+](../flight_controller/cuav_v5_plus.md)
 * [V5 nano](../flight_controller/cuav_v5_nano.md)
 
-> **Note** This is not an exhaustive list of all boards that can run PX4. Other boards are linked from the sidebar, and there may be other flight controllers that we have not documented.
+> **Note** This is not an exhaustive list of all boards that can run PX4.
+Other boards are linked from the sidebar, and there may be other flight controllers that we have not documented.
 
 The rest of this topic explains a bit more about the Pixhawk series, but is not required reading.
 
@@ -51,19 +52,22 @@ Manufacturers are encouraged to take the [open designs](https://github.com/PX4/H
 
 The project also creates reference autopilot boards based on the open designs, and shares them under the same [licence](#licensing-and-trademarks).
 
-### FMU Versions
+### FMU Versions {#fmu_versions}
 
 The Pixhawk project has created a number of different open designs/schematics.
 All boards based on a design should be binary compatible (run the same firmware).
 
 Each design is named using the designation: FMUvX (e.g.: FMUv1, FMUv2, FMUv3, FMUv4, etc.).
-Higher FMU numbers indicate that the board is more recent,
-but may not indicate increased capability (versions can be almost identical - differing only in connector wiring).
+Higher FMU numbers indicate that the board is more recent, but may not indicate increased capability (versions can be almost identical - differing only in connector wiring).
 
 PX4 *users* generally do not need to know very much about FMU versions:
-- *QGroundControl* automatically downloads the correct firmware for a connected autopilot (based on its FMU version "under the hood").
-- Choosing a controller is usually based on physical constraints/form factor rather than FMU version.
+  - *QGroundControl* automatically downloads the correct firmware for a connected autopilot (based on its FMU version "under the hood").
+  - Choosing a controller is usually based on physical constraints/form factor rather than FMU version.
 
+  > **Note** The exception is that if you're using FMUv2 firmware it is [limited to 1MB of flash](../flight_controller/silicon_errata.md#fmuv2--pixhawk-silicon-errata).
+  In order to fit PX4 into this limited space, many modules are disabled by default.
+  You may find that some [parameters are missing](../advanced_config/parameters.md#missing) and that some hardware does not work "out of the box".
+  
 PX4 *developers* need to know the FMU version of their board, as this is required to build custom hardware.
 
 At very high level, the main differences are:
@@ -74,7 +78,7 @@ At very high level, the main differences are:
 - **FMUv4-PRO:** Slightly increased RAM. More serial ports. IO processor ([Pixhawk 3 Pro](../flight_controller/pixhawk3_pro.md))
 - **FMUv5:** New processor (F7). Much faster. More RAM. More CAN busses. Much more configurable.([Pixhawk 4](../flight_controller/pixhawk4.md),[CUAV v5](../flight_controller/cuav_v5.md),[CUAV V5+](../flight_controller/cuav_v5_plus.md),[CUAV V5 nano](../flight_controller/cuav_v5_nano.md))
 
-### Licensing and trademarks
+### Licensing and Trademarks {#licensing-and-trademarks}
 
 Pixhawk project schematics and reference designs are licensed under [CC BY-SA 3](https://creativecommons.org/licenses/by-sa/3.0/legalcode).
 

--- a/en/getting_started/flight_controller_selection.md
+++ b/en/getting_started/flight_controller_selection.md
@@ -3,23 +3,25 @@
 You should select a board that suits the physical constraints of your vehicle, the activities you wish to perform, and of course cost.
 
 PX4 can run on many flight controller boards (see [Autopilot Hardware](../flight_controller/README.md), or the list of supported boards [here on Github](https://github.com/PX4/Firmware/#supported-hardware)). 
-A *subset* of the available options are listed below. 
+A *small subset* of the available options are listed below. 
 
 ## Pixhawk Series
 
-[Pixhawk Series](../flight_controller/pixhawk_series.md) open-hardware flight controllers run PX4 on NuttX OS. With many form factors, there are versions targeted towards many use cases and market segments. 
+[Pixhawk Series](../flight_controller/pixhawk_series.md) open-hardware flight controllers run PX4 on NuttX OS.
+With many form factors, there are versions targeted towards many use cases and market segments.
 
-> **Tip** If you need computer vision or other computationally intensive tasks then instead consider a [board with companion computing](#autopilots-for-computationally-intensive-tasks).
+> **Tip** We recommend you use Pixhawk boards that can run firmware FMUv3 and later (may require a [bootloader update](../config/firmware.md#bootloader)).
 
 Controller | Description
 --- | ---
-[mRo Pixhawk](../flight_controller/mro_pixhawk.md) | Popular *general purpose* flight controller (this is a *slightly updated* version of the discontinued 3DR [Pixhawk 1](../flight_controller/pixhawk.md)). <br>Also consider: [HKPilot32](../flight_controller/HKPilot32.md), [Dropix](../flight_controller/dropix.md), [mRobotics-X2.1](../flight_controller/mro_x2.1.md).
-[Pixracer](../flight_controller/pixracer.md) | Very small/light autopilot optimised for FPV racers. It is suited to any small frame that requires no more than 6 PWM outputs. <br>Also consider:  [Pixhawk 3 Pro](../flight_controller/pixhawk3_pro.md), [MindRacer](../flight_controller/mindracer.md), [Pixfalcon](../flight_controller/pixfalcon.md).
-[Pixhawk Mini](../flight_controller/pixhawk_mini.md) | Small *general purpose* autopilot that has been optimised for ease of setup.<br>The controller has internal vibration damping and only 8 main outputs (**no AUX ports**), making it much less daunting to install and connect. It is not suitable for vehicles/functions that *require* AUX ports.
-[Pixhawk 2](../flight_controller/pixhawk-2.md) | Flexible autopilot intended primarily for manufacturers of commercial systems. It is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
-[Pixhawk 4](../flight_controller/pixhawk4.md) | Pixhawk 4 is optimized to run PX4 version 1.7 and is suitable for academic and commercial developers. It features more computing power and 2X the RAM than previous versions, additional ports for better integration and expansion, new sensors and integrated vibration isolation.
-[CUAV V5+](../flight_controller/cuav_v5_plus.md) | The board is based on the Pixhawk **FMUv5 design standard**, the external interface uses the [Pixhawk standard pinouts](https://pixhawk.org/pixhawk-connector-standard/), and the modular design allows the users to customize their own carrier board. The autopilot is compatible [PX4](http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v5_default.px4) firmware.can be used for academic research and commercial systems integration.
 [CUAV V5 nano](../flight_controller/cuav_v5_nano.md) | Based on the Pixhawk **FMUv5** design standard and optimized to run PX4 firmware. Small enough to use in 220mm racing drones, but powerful enough for almost any other drone use.
+[CUAV V5+](../flight_controller/cuav_v5_plus.md) | The board is based on the Pixhawk **FMUv5 design standard**, the external interface uses the [Pixhawk standard pinouts](https://pixhawk.org/pixhawk-connector-standard/), and the modular design allows the users to customize their own carrier board. The autopilot is compatible [PX4](http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v5_default.px4) firmware.can be used for academic research and commercial systems integration.
+[Pixhawk 4](../flight_controller/pixhawk4.md) | Pixhawk 4 is optimized to run PX4 version 1.7 and is suitable for academic and commercial developers. It features more computing power and 2X the RAM than previous versions, additional ports for better integration and expansion, new sensors and integrated vibration isolation.
+[Pixhawk 2/Cube](../flight_controller/pixhawk-2.md) | Flexible autopilot intended primarily for manufacturers of commercial systems. It is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
+[Pixracer](../flight_controller/pixracer.md) | Very small/light autopilot optimised for FPV racers. It is suited to any small frame that requires no more than 6 PWM outputs. <br>Also consider:  [Pixhawk 3 Pro](../flight_controller/pixhawk3_pro.md), [MindRacer](../flight_controller/mindracer.md).
+[mRo Pixhawk](../flight_controller/mro_pixhawk.md) | Popular *general purpose* flight controller (this is an FMUv3 version of the discontinued 3DR [Pixhawk 1](../flight_controller/pixhawk.md)).
+
+
 
 ## Autopilots for Computationally Intensive Tasks
 


### PR DESCRIPTION
We still get quite a lot of questions about why parameters might be missing, and most of the time this is due to using FMUv2 hardware.

This fix adds generic docs on why a parameter might be missing/not visible and how you can solve that problem.

It also adds info about the FMUv2 limitation in a number of places (to make it more obvious) and removes the FMUv2 boards from "recommended lists". 