### PR TITLE
SFxxx rangefinder: remove param list

### DIFF
--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -14,7 +14,8 @@ The following models are supported by PX4, and can be connected to either the I2
 Model | Range (m) | Bus | Description
 --- | --- | --- | ---
 [SF11/C](https://lightware.co.za/collections/lidar-rangefinders/products/sf11-c-120-m) | 120 | Serial or I2C bus | 
-[LW20](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) | 100 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
+[LW20/B](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) | 50 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
+[LW20/C](http://lightware.co.za/shop2017/drone-altimeters/51-lw20-100-m.html) | 100 | I2C bus | Waterproofed (IP67) with servo for sense-and-avoid applications
 
 ### Discontinued
 
@@ -45,13 +46,7 @@ Connect the Lidar the autopilot I2C port as shown below (in this case, for the [
 
 ### Parameter Setup {#i2c_parameter_setup}
 
-Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX) parameter to match the rangefinder model and then reboot:
-* `0`: Disabled
-* `1`: SF10/a
-* `2`: SF10/b
-* `3`: SF10/c
-* `4`: SF11/c
-* `5`: SF/LW20
+Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX) parameter to match the rangefinder model and then reboot.
 
 
 ## Serial Setup
@@ -69,13 +64,7 @@ There is no need to set the baud rate for the port, as this is configured by the
 
 > **Note** If the configuration parameter is not available in *QGroundControl* then you may need to [add the driver to the firmware](../peripherals/serial_configuration.md#parameter_not_in_firmware).
 
-Then set the [SENS_EN_SF0X](../advanced_config/parameter_reference.md#SENS_EN_SF0X) parameter to match the rangefinder model and reboot:
-* `0`: Disabled
-* `1`: SF02
-* `2`: SF10/a
-* `3`: SF10/b
-* `4`: SF10/c
-* `5`: SF11/c
+Then set the [SENS_EN_SF0X](../advanced_config/parameter_reference.md#SENS_EN_SF0X) parameter to match the rangefinder model and reboot.
 
 ## Further Information
 


### PR DESCRIPTION
Follows on from https://github.com/PX4/Firmware/pull/12918

@mcsauder This makes  SF/LW20/b and 6: SF/LW20/c separate records in docs. I also removed the list of options for selecting the rangefinder version, since that is in the parameter itself. Look OK to you?