### PR TITLE
update collision prevention description

### DIFF
--- a/en/computer_vision/collision_prevention.md
+++ b/en/computer_vision/collision_prevention.md
@@ -14,7 +14,7 @@ It also prevents motion in directions where no sensor data is available (i.e. if
 
 ## Overview
 
-*Collision Prevention* is enabled on PX4 by setting the parameter for minimum allowed approach distance ([MPC_COL_PREV_D](#MPC_COL_PREV_D)).
+*Collision Prevention* is enabled on PX4 by setting the parameter for minimum allowed approach distance ([CP_DIST](#CP_DIST)).
 
 The feature requires obstacle information from an external system (sent using the MAVLink [OBSTACLE_DISTANCE](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) message) and/or a [distance sensor](../sensor/rangefinders.md) connected to the flight controller.
 
@@ -38,9 +38,10 @@ Configure collision prevention by [setting the following parameters](../advanced
 
 Parameter | Description
 --- | ---
-<span id="MPC_COL_PREV_DLY"></span>[MPC_COL_PREV_D](../advanced_config/parameter_reference.md#MPC_COL_PREV_D) | Set the minimum allowed distance (the closest distance that the vehicle can approach the obstacle). Set negative to disable *collision prevention*. <br>> **Warning** This value is the distance to the sensors, not the outside of your vehicle or propellers. Be sure to leave a safe margin!
-<span id="MPC_COL_PREV_DLY"></span>[MPC_COL_PREV_DLY](../advanced_config/parameter_reference.md#MPC_COL_PREV_DLY) | Set the sensor and velocity setpoint tracking delay. See [Delay Tuning](#delay_tuning) below.
-<span id="MPC_COL_PREV_CNG"></span>[MPC_COL_PREV_CNG](../advanced_config/parameter_reference.md#MPC_COL_PREV_CNG) | Set the angle (to both sides of the commanded direction) within which the vehicle may deviate if it finds fewer obstacles in that direction. See [Guidance Tuning](#angle_change_tuning) below.
+<span id="CP_DELAY"></span>[CP_DIST](../advanced_config/parameter_reference.md#CP_DIST) | Set the minimum allowed distance (the closest distance that the vehicle can approach the obstacle). Set negative to disable *collision prevention*. <br>> **Warning** This value is the distance to the sensors, not the outside of your vehicle or propellers. Be sure to leave a safe margin!
+<span id="CP_DELAY"></span>[CP_DELAY](../advanced_config/parameter_reference.md#CP_DELAY) | Set the sensor and velocity setpoint tracking delay. See [Delay Tuning](#delay_tuning) below.
+<span id="CP_GUIDE_ANG"></span>[CP_GUIDE_ANG](../advanced_config/parameter_reference.md#CP_GUIDE_ANG) | Set the angle (to both sides of the commanded direction) within which the vehicle may deviate if it finds fewer obstacles in that direction. See [Guidance Tuning](#angle_change_tuning) below.
+<span id="CP_GO_NO_DATA"></span>[CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) | Boolean to allow vehicle movement where there is no sensor coverage (default set to False).
 
 
 ## Algorithm Description {#algorithm}
@@ -50,22 +51,22 @@ When the vehicle is commanded to move in a particular direction, all sectors in 
 If so, the vehicle velocity is restricted.
 
 This velocity restriction takes into account both the inner velocity loop tuned by [MPC_XY_P](../advanced_config/parameter_reference.md#MPC_XY_P), as well as the [jerk-optimal velocity controller](../config_mc/mc_jerk_limited_type_trajectory.md) via [MPC_JERK_MAX](../advanced_config/parameter_reference.md#MPC_JERK_MAX) and [MPC_ACC_HOR](../advanced_config/parameter_reference.md#MPC_ACC_HOR).
-The velocity is restricted such that the vehicle will stop in time to maintain the distance specified in [MPC_COL_PREV_D](#MPC_COL_PREV_D).
+The velocity is restricted such that the vehicle will stop in time to maintain the distance specified in [CP_DIST](#CP_DIST).
 The range of the sensors for each sector is also taken into account, limiting the velocity via the same mechanism.
 
-> **Note** If there is no sensor data in a particular direction, velocity in that direction is restricted to 0 (preventing the vehicle from crashing into unseen objects).
+> **Note** If there is no sensor data in a particular direction, velocity in that direction is restricted to 0 (preventing the vehicle from crashing into unseen objects). If you wish to move freely into directions without sensor coverage, this can be enabled by setting [CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) to 1.
 
-Delay, both in the vehicle tracking velocity setpoints and in receiving sensor data from external sources, is conservatively estimated via the [MPC_COL_PREV_DLY](#MPC_COL_PREV_DLY) parameter.
+Delay, both in the vehicle tracking velocity setpoints and in receiving sensor data from external sources, is conservatively estimated via the [CP_DELAY](#CP_DELAY) parameter.
 This should be [tuned](#delay_tuning) to the specific vehicle.
 
-If the sectors adjacent to the commanded sectors are 'better' by a significant margin, the direction of the requested input can be modified by up to the angle specified in [MPC_COL_PREV_CNG](#MPC_COL_PREV_CNG).
+If the sectors adjacent to the commanded sectors are 'better' by a significant margin, the direction of the requested input can be modified by up to the angle specified in [CP_GUIDE_ANG](#CP_GUIDE_ANG).
 This helps to fine-tune user input to 'guide' the vehicle around obstacles rather than getting stuck against them.
 
 
-### MPC_COL_PREV_DLY Delay Tuning {#delay_tuning}
+### CP_DELAY Delay Tuning {#delay_tuning}
 
 There are two main sources of delay which should be accounted for: *sensor delay*, and vehicle *velocity setpoint tracking delay*.
-Both sources of delay are tuned using the [MPC_COL_PREV_DLY](#MPC_COL_PREV_DLY) parameter.
+Both sources of delay are tuned using the [CP_DELAY](#CP_DELAY) parameter.
 
 <!-- Not yet answered (fully) how to get sensor delay and how interacts with the setpoint tracking delay.
   From @jkflying
@@ -82,10 +83,10 @@ The tracking delay is typically between 0.1 and 0.5 seconds, depending on vehicl
 
 > **Tip** If vehicle speed oscillates as it approaches the obstacle (i.e. it slows down, speeds up, slows down) the delay is set too high.
 
-### MPC_COL_PREV_CNG Guidance Tuning {#angle_change_tuning}
+### CP_GUIDE_ANG Guidance Tuning {#angle_change_tuning}
 
 Depending on the vehicle, type of environment and pilot skill different amounts of guidance may be desired.
-Setting the [MPC_COL_PREV_CNG](../advanced_config/parameter_reference.md#MPC_COL_PREV_CNG) parameter to 0 will disable the guidance, resulting in the vehicle only moving exactly in the directions commanded.
+Setting the [CP_GUIDE_ANG](../advanced_config/parameter_reference.md#CP_GUIDE_ANG) parameter to 0 will disable the guidance, resulting in the vehicle only moving exactly in the directions commanded.
 Increasing this parameter will let the vehicle choose optimal directions to avoid obstacles, making it easier to fly through tight gaps and to keep the minimum distance exactly while going around objects.
 
 If this parameter is too small the vehicle may feel 'stuck' when close to obstacles, because only movement away from obstacles at minimum distance are allowed.
@@ -99,13 +100,13 @@ From testing, 30 degrees is a good balance, although different vehicles may have
 ## PX4 Distance Sensor {#rangefinder}
 
 At time of writing PX4 allows you to use the [Lanbao PSK-CM8JL65-CC5](../sensor/cm8jl65_ir_distance_sensor.md) IR distance sensor for collision prevention "out of the box", with minimal additional configuration:
-- First [attach and configure the sensor](../sensor/cm8jl65_ir_distance_sensor.md), and enable collision prevention (as described above, using `MPC_COL_PREV_D`).
+- First [attach and configure the sensor](../sensor/cm8jl65_ir_distance_sensor.md), and enable collision prevention (as described above, using `CP_DIST`).
 - Set the sensor orientation using [SENS_CM8JL65_R_0](../advanced_config/parameter_reference.md#SENS_CM8JL65_R_0).
 
 <!-- ROTATION_FORWARD_FACING - Does it matter what angles? - ie is collision prevention active in 3 D? -->
 
 Other sensors may be enabled, but this requires modification of driver code to set the sensor orientation and field of view.
-- Attach and configure the distance sensor on a particular port (see [sensor-specific docs](../sensor/rangefinders.md)) and enable collision prevention using `MPC_COL_PREV_D`.
+- Attach and configure the distance sensor on a particular port (see [sensor-specific docs](../sensor/rangefinders.md)) and enable collision prevention using `CP_DIST`.
 - Modify the driver to set the orientation.
   This should be done by mimicking the `SENS_CM8JL65_R_0` parameter (though you might also hard-code the orientation in the sensor *module.yaml* file to something like `sf0x start -d ${SERIAL_DEV} -R 25` - where 25 is equivalent to `ROTATION_DOWNWARD_FACING`).
 - Modify the driver to set the *field of view* in the distance sensor UORB topic (`distance_sensor_s.h_fov`).

--- a/en/computer_vision/collision_prevention.md
+++ b/en/computer_vision/collision_prevention.md
@@ -38,10 +38,10 @@ Configure collision prevention by [setting the following parameters](../advanced
 
 Parameter | Description
 --- | ---
-<span id="CP_DELAY"></span>[CP_DIST](../advanced_config/parameter_reference.md#CP_DIST) | Set the minimum allowed distance (the closest distance that the vehicle can approach the obstacle). Set negative to disable *collision prevention*. <br>> **Warning** This value is the distance to the sensors, not the outside of your vehicle or propellers. Be sure to leave a safe margin!
+<span id="CP_DIST"></span>[CP_DIST](../advanced_config/parameter_reference.md#CP_DIST) | Set the minimum allowed distance (the closest distance that the vehicle can approach the obstacle). Set negative to disable *collision prevention*. <br>> **Warning** This value is the distance to the sensors, not the outside of your vehicle or propellers. Be sure to leave a safe margin!
 <span id="CP_DELAY"></span>[CP_DELAY](../advanced_config/parameter_reference.md#CP_DELAY) | Set the sensor and velocity setpoint tracking delay. See [Delay Tuning](#delay_tuning) below.
 <span id="CP_GUIDE_ANG"></span>[CP_GUIDE_ANG](../advanced_config/parameter_reference.md#CP_GUIDE_ANG) | Set the angle (to both sides of the commanded direction) within which the vehicle may deviate if it finds fewer obstacles in that direction. See [Guidance Tuning](#angle_change_tuning) below.
-<span id="CP_GO_NO_DATA"></span>[CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) | Boolean to allow vehicle movement where there is no sensor coverage (default set to False).
+<span id="CP_GO_NO_DATA"></span>[CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) | Set to 1 to allow the vehicle to move in directions where there is no sensor coverage (default is 0/`False`).
 
 
 ## Algorithm Description {#algorithm}
@@ -54,7 +54,7 @@ This velocity restriction takes into account both the inner velocity loop tuned 
 The velocity is restricted such that the vehicle will stop in time to maintain the distance specified in [CP_DIST](#CP_DIST).
 The range of the sensors for each sector is also taken into account, limiting the velocity via the same mechanism.
 
-> **Note** If there is no sensor data in a particular direction, velocity in that direction is restricted to 0 (preventing the vehicle from crashing into unseen objects). If you wish to move freely into directions without sensor coverage, this can be enabled by setting [CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) to 1.
+> **Note** If there is no sensor data in a particular direction, velocity in that direction is restricted to 0 (preventing the vehicle from crashing into unseen objects). If you wish to move freely into directions without sensor coverage, this can be enabled by setting [CP_GO_NO_DATA](#CP_GO_NO_DATA) to 1.
 
 Delay, both in the vehicle tracking velocity setpoints and in receiving sensor data from external sources, is conservatively estimated via the [CP_DELAY](#CP_DELAY) parameter.
 This should be [tuned](#delay_tuning) to the specific vehicle.
@@ -68,12 +68,6 @@ This helps to fine-tune user input to 'guide' the vehicle around obstacles rathe
 There are two main sources of delay which should be accounted for: *sensor delay*, and vehicle *velocity setpoint tracking delay*.
 Both sources of delay are tuned using the [CP_DELAY](#CP_DELAY) parameter.
 
-<!-- Not yet answered (fully) how to get sensor delay and how interacts with the setpoint tracking delay.
-  From @jkflying
-    Characterizing sensor delay is a huge pain. 
-    We did it by overlaying a known-low-latency sensor onto our unknown sensor, and then applying movements. 
-    Not sure if there is a better way. -->
-
 The *sensor delay* for distance sensors connected directly to the flight controller can be assumed to be 0.
 For external vision-based systems the sensor delay may be as high as 0.2s.
 
@@ -86,7 +80,7 @@ The tracking delay is typically between 0.1 and 0.5 seconds, depending on vehicl
 ### CP_GUIDE_ANG Guidance Tuning {#angle_change_tuning}
 
 Depending on the vehicle, type of environment and pilot skill different amounts of guidance may be desired.
-Setting the [CP_GUIDE_ANG](../advanced_config/parameter_reference.md#CP_GUIDE_ANG) parameter to 0 will disable the guidance, resulting in the vehicle only moving exactly in the directions commanded.
+Setting the [CP_GUIDE_ANG](#CP_GUIDE_ANG) parameter to 0 will disable the guidance, resulting in the vehicle only moving exactly in the directions commanded.
 Increasing this parameter will let the vehicle choose optimal directions to avoid obstacles, making it easier to fly through tight gaps and to keep the minimum distance exactly while going around objects.
 
 If this parameter is too small the vehicle may feel 'stuck' when close to obstacles, because only movement away from obstacles at minimum distance are allowed.
@@ -100,13 +94,12 @@ From testing, 30 degrees is a good balance, although different vehicles may have
 ## PX4 Distance Sensor {#rangefinder}
 
 At time of writing PX4 allows you to use the [Lanbao PSK-CM8JL65-CC5](../sensor/cm8jl65_ir_distance_sensor.md) IR distance sensor for collision prevention "out of the box", with minimal additional configuration:
-- First [attach and configure the sensor](../sensor/cm8jl65_ir_distance_sensor.md), and enable collision prevention (as described above, using `CP_DIST`).
+- First [attach and configure the sensor](../sensor/cm8jl65_ir_distance_sensor.md), and enable collision prevention (as described above, using [CP_DIST](#CP_DIST)).
 - Set the sensor orientation using [SENS_CM8JL65_R_0](../advanced_config/parameter_reference.md#SENS_CM8JL65_R_0).
 
-<!-- ROTATION_FORWARD_FACING - Does it matter what angles? - ie is collision prevention active in 3 D? -->
 
 Other sensors may be enabled, but this requires modification of driver code to set the sensor orientation and field of view.
-- Attach and configure the distance sensor on a particular port (see [sensor-specific docs](../sensor/rangefinders.md)) and enable collision prevention using `CP_DIST`.
+- Attach and configure the distance sensor on a particular port (see [sensor-specific docs](../sensor/rangefinders.md)) and enable collision prevention using [CP_DIST](#CP_DIST).
 - Modify the driver to set the orientation.
   This should be done by mimicking the `SENS_CM8JL65_R_0` parameter (though you might also hard-code the orientation in the sensor *module.yaml* file to something like `sf0x start -d ${SERIAL_DEV} -R 25` - where 25 is equivalent to `ROTATION_DOWNWARD_FACING`).
 - Modify the driver to set the *field of view* in the distance sensor UORB topic (`distance_sensor_s.h_fov`).


### PR DESCRIPTION
After the upstream merge of: https://github.com/PX4/Firmware/pull/13135 the parameter names in the collision prevention changed. There was also an option added to enable movement into directions without sensor coverage. This PR updates the description in the user guide.