### PR TITLE
Update supported offboard mode setpoints for rover

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -88,6 +88,7 @@ See https://github.com/PX4/Firmware/pull/12149 and https://github.com/PX4/Firmwa
 * [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)
   * The following input combinations are supported:
     * Attitude/orientation (`SET_ATTITUDE_TARGET.q`) with thrust setpoint (`SET_ATTITUDE_TARGET.thrust`).
+      > **Note** Only the yaw setting is actually used/extracted.
 
 ## Offboard Parameters
 

--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -77,12 +77,17 @@ See https://github.com/PX4/Firmware/pull/12149 and https://github.com/PX4/Firmwa
 * [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
   * The following input combinations are supported: <!-- https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
     * Position setpoint (only `x`, `y`, `z`)
+    * Velocity setpoint (only `vx`, `yy`, `vz`)
   - PX4 supports the coordinate frames (`coordinate_frame` field): [MAV_FRAME_LOCAL_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_LOCAL_NED) and [MAV_FRAME_BODY_NED](https://mavlink.io/en/messages/common.html#MAV_FRAME_BODY_NED).
 
 * [SET_POSITION_TARGET_GLOBAL_INT](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT)
   * The following input combinations are supported: <!-- https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
     * Position setpoint (only `lat_int`, `lon_int`, `alt`)
   - PX4 supports the coordinate frames (`coordinate_frame` field): [MAV_FRAME_GLOBAL](https://mavlink.io/en/messages/common.html#MAV_FRAME_GLOBAL).
+
+* [SET_ATTITUDE_TARGET](https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET)
+  * The following input combinations are supported:
+    * Attitude/orientation (`SET_ATTITUDE_TARGET.q`) with thrust setpoint (`SET_ATTITUDE_TARGET.thrust`).
 
 ## Offboard Parameters
 


### PR DESCRIPTION
This PR updates the documentation in rover to include the recent added support for offboard setpoints.
- Attitude setpoints: https://github.com/PX4/Firmware/pull/13323
- Velocity setpoints: https://github.com/PX4/Firmware/pull/13363 https://github.com/PX4/Firmware/pull/13225 