### PR TITLE
Racersetup: Remove SYS_FMU_TASK

### DIFF
--- a/en/config_mc/racer_setup.md
+++ b/en/config_mc/racer_setup.md
@@ -122,6 +122,7 @@ Even one millisecond added to the latency makes a difference.
 These are the factors that affect the latency:
 - A soft airframe or soft vibration mounting increases latency (they act as a filter).
 - Low-pass filters in software and on the sensor chip trade off increased latency for improved noise filtering.
+- PX4 software internals: the sensor signals need to be read in the driver and then pass through the controller to the output driver.
 - The IO chip (MAIN pins) adds about 5.4 ms latency compared to using the AUX pins (this does not apply to a *Pixracer* or *Omnibus F4*, but does apply to a Pixhawk).
   To avoid the IO delay, disable [SYS_USE_IO](../advanced_config/parameter_reference.md#SYS_USE_IO) and attach the motors to the AUX pins instead.
 - PWM output signal: enable One-Shot to reduce latency ([PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE)=0) 

--- a/en/config_mc/racer_setup.md
+++ b/en/config_mc/racer_setup.md
@@ -72,7 +72,6 @@ airframe, which already sets some racer-specific parameters.
 
 These parameters are important:
 - Enable One-Shot by setting [PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE) to 0.
-- Enable `SYS_FMU_TASK` (explained [below](#control_latency)).
 - Set the maximum roll-, pitch- and yaw rates for Manual/Stabilized mode as
   desired: [MC_ROLLRATE_MAX](../advanced_config/parameter_reference.md#MC_ROLLRATE_MAX), [MC_PITCHRATE_MAX](../advanced_config/parameter_reference.md#MC_PITCHRATE_MAX) and [MC_YAWRATE_MAX](../advanced_config/parameter_reference.md#MC_YAWRATE_MAX).
   The maximum tilt angle is configured with [MPC_MAN_TILT_MAX](../advanced_config/parameter_reference.md#MPC_MAN_TILT_MAX).
@@ -123,8 +122,6 @@ Even one millisecond added to the latency makes a difference.
 These are the factors that affect the latency:
 - A soft airframe or soft vibration mounting increases latency (they act as a filter).
 - Low-pass filters in software and on the sensor chip trade off increased latency for improved noise filtering.
-- PX4 software internals: the sensor signals need to be read in the driver and then pass through the controller to the output driver.
-  Enable [SYS_FMU_TASK](../advanced_config/parameter_reference.md#SYS_FMU_TASK) to reduce latency (default on [Pixracer](../flight_controller/pixracer.md) and [Omnibus F4 SD](../flight_controller/omnibus_f4_sd.md)).
 - The IO chip (MAIN pins) adds about 5.4 ms latency compared to using the AUX pins (this does not apply to a *Pixracer* or *Omnibus F4*, but does apply to a Pixhawk).
   To avoid the IO delay, disable [SYS_USE_IO](../advanced_config/parameter_reference.md#SYS_USE_IO) and attach the motors to the AUX pins instead.
 - PWM output signal: enable One-Shot to reduce latency ([PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE)=0) 


### PR DESCRIPTION
SYS_FMU_TASK no longer exists. 