### PR TITLE
Update pre_flight_checks.md

### DIFF
--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -29,6 +29,8 @@ The following errors (with associated checks and parameters) are reported by the
 * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
 * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
 * The check is controlled by the [COM_ARM_EKF_YAW](../advanced_config/parameter_reference.md#COM_ARM_EKF_YAW) parameter
+* The default value of 0.5 allows the differences between the navigation yaw angle and magnetic yaw angle (magnetometer or external vision) to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences.
+* It can fail if the yaw gyro has a large offset or if the vehicle is moved or rotated in the presence of a bad magnetic interference or magnetometer calibration.
 
 `PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS`:
 * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 

--- a/en/flying/pre_flight_checks.md
+++ b/en/flying/pre_flight_checks.md
@@ -28,7 +28,7 @@ The following errors (with associated checks and parameters) are reported by the
 `PREFLIGHT FAIL: EKF YAW ERROR`:
 * This error is produced when the yaw angle estimated using gyro data and the yaw angle from the magnetometer or external vision system are inconsistent.
 * Check the IMU data for large yaw rate offsets and check the magnetometer alignment and calibration.
-* The check is controlled by the [COM_ARM_EKF_POS](../advanced_config/parameter_reference.md#COM_ARM_EKF_POS) parameter
+* The check is controlled by the [COM_ARM_EKF_YAW](../advanced_config/parameter_reference.md#COM_ARM_EKF_YAW) parameter
 
 `PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS`:
 * This error is produced when the IMU accelerometer bias estimated by the EKF is excessive. 
@@ -73,9 +73,4 @@ The following parameters also affect preflight checks.
 The [COM_ARM_WO_GPS](../advanced_config/parameter_reference.md#COM_ARM_WO_GPS) parameter controls whether or not arming is allowed without a global position estimate. 
 - `1` (default): Arming *is* allowed without a position estimate for flight modes that do not require position information (only).
 - `0`: Arming is allowed only if EKF is providing a global position estimate and EFK GPS quality checks are passing
-
-
-### COM_ARM_EKF_YAW
-
-The [COM_ARM_EKF_YAW](../advanced_config/parameter_reference.md#COM_ARM_EKF_YAW) parameter determines the maximum difference (in radians) between the navigation yaw angle and magnetic yaw angle (magnetometer or external vision) allowed before preflight checks fail. The default value of 0.5 allows the differences to be no more than 50% of the maximum tolerated by the EKF and provides some margin for error increase when flight commences. It can fail if the yaw gyro has a large offset or if the vehicle is moved or rotated in the presence of a bad magnetic interference or magnetometer calibration.
 


### PR DESCRIPTION
Fix a typo (form copy/paste error) COM_ARM_EKF_POS --> COM_ARM_EKF_YAW in PREFLIGHT FAIL: EKF YAW ERROR section

remove COM_ARM_EKF_YAW section because it is redundant with the corrected section above and the first sentence is confusing (not a threshold in radians but an innovation ratio)