### PR TITLE
missions: clarify how to set yaw

### DIFF
--- a/en/flying/missions.md
+++ b/en/flying/missions.md
@@ -18,10 +18,12 @@ You can also use the *Pattern* tool to automate creation of survey grids.
 
 ### Setting Vehicle Yaw
 
-If set, a vehicle will yaw to face the **Heading** value specified in the target waypoint (corresponding to [MAV_CMD_NAV_WAYPOINT.param4](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT)).
+If set, a multi-rotor vehicle will yaw to face the **Heading** value specified in the target waypoint (corresponding to [MAV_CMD_NAV_WAYPOINT.param4](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT)).
 
 If **Heading** has not been explicitly set for the target waypoint (`param4=NaN`) then the vehicle will yaw towards a location specified in the parameter [MPC_YAW_MODE](../advanced_config/parameter_reference.md#MPC_YAW_MODE).
 By default this is the next waypoint.
+
+Vehicle types that cannot independently control yaw and direction of travel will ignore yaw settings (e.g. Fixed Wing).
 
 ## Flying Missions
 

--- a/en/flying/missions.md
+++ b/en/flying/missions.md
@@ -16,6 +16,12 @@ You can also use the *Pattern* tool to automate creation of survey grids.
 
 ![planning-mission](../../images/planning_mission.jpg)
 
+### Setting Vehicle Yaw
+
+If set, a vehicle will yaw to face the **Heading** value specified in the target waypoint (corresponding to [MAV_CMD_NAV_WAYPOINT.param4](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT)).
+
+If **Heading** has not been explicitly set for the target waypoint (`param4=NaN`) then the vehicle will yaw towards a location specified in the parameter [MPC_YAW_MODE](../advanced_config/parameter_reference.md#MPC_YAW_MODE).
+By default this is the next waypoint.
 
 ## Flying Missions
 


### PR DESCRIPTION
This comes up quite a lot. Thought it useful to add a link. 

Note, behaviour differs slightly from MAVLink spec, which indicates that if yaw not set then the vehicle heading should be unchanged.