### PR TITLE
Add HKPilot32 SWD link

### DIFF
--- a/en/flight_controller/HKPilot32.md
+++ b/en/flight_controller/HKPilot32.md
@@ -63,6 +63,11 @@ To [build PX4](https://dev.px4.io/master/en/setup/building_px4.html) for this ta
 make px4_fmu-v2_default
 ```
 
+## Debug Ports
+
+See [3DR Pixhawk 1 > Debug Ports](../flight_controller/pixhawk.md#debug-ports).
+
+
 ## Pinouts and Schematics
 
 The board is based on the [Pixhawk project](https://pixhawk.org/) **FMUv2** open hardware design.

--- a/en/flight_controller/HKPilot32.md
+++ b/en/flight_controller/HKPilot32.md
@@ -63,7 +63,7 @@ To [build PX4](https://dev.px4.io/master/en/setup/building_px4.html) for this ta
 make px4_fmu-v2_default
 ```
 
-## Debug Ports
+## Debug Port
 
 See [3DR Pixhawk 1 > Debug Ports](../flight_controller/pixhawk.md#debug-ports).
 

--- a/en/flight_controller/pixfalcon.md
+++ b/en/flight_controller/pixfalcon.md
@@ -47,6 +47,13 @@ To [build PX4](https://dev.px4.io/master/en/setup/building_px4.html) for this ta
 make px4_fmu-v2_default
 ```
 
+## Debug Port
+
+This board does not have a debug port (i.e it does not have a port for accessing the [System Console](http://dev.px4.io/master/en/debug/system_console.html) or SWD (JTAG) debug interface.
+
+In order to access these interfaces developers would need to solder wires to the board test pads for SWD and IC to a console.
+
+
 ## Key Links
 
 * [User Manual](http://www.holybro.com/manual/pixfalcon11.pdf)

--- a/en/flight_controller/pixfalcon.md
+++ b/en/flight_controller/pixfalcon.md
@@ -51,7 +51,7 @@ make px4_fmu-v2_default
 
 This board does not have a debug port (i.e it does not have a port for accessing the [System Console](http://dev.px4.io/master/en/debug/system_console.html) or SWD (JTAG) debug interface.
 
-In order to access these interfaces developers would need to solder wires to the board test pads for SWD and IC to a console.
+Developers will need to solder wires to the board test pads for SWD, and to the STM32F4 (IC) TX and RX to get a console.
 
 
 ## Key Links

--- a/en/flight_controller/pixhawk_mini.md
+++ b/en/flight_controller/pixhawk_mini.md
@@ -296,7 +296,7 @@ make px4_fmu-v2_default
 
 This board does not have a debug port (i.e it does not have a port for accessing the [System Console](http://dev.px4.io/master/en/debug/system_console.html) or SWD (JTAG) debug interface.
 
-In order to access these developers would need to solder wires to the board test pads for SWD and IC to a console.
+Developers will need to solder wires to the board test pads for SWD, and to the STM32F4 (IC) TX and RX to get a console.
 
 
 ### Other Peripherals

--- a/en/flight_controller/pixhawk_mini.md
+++ b/en/flight_controller/pixhawk_mini.md
@@ -282,6 +282,23 @@ Notes:
 <img src="../../images/pixhawk_mini_port_main_out.png" width="350px" title="Pixhawk Mini - port for motors/servos" />
 
 
+## Building Firmware
+
+> **Tip** Most users will not need to build this firmware!
+  It is pre-built and automatically installed by *QGroundControl* when appropriate hardware is connected.
+
+To [build PX4](https://dev.px4.io/master/en/setup/building_px4.html) for this target:
+```
+make px4_fmu-v2_default
+```
+
+## Debug Port
+
+This board does not have a debug port (i.e it does not have a port for accessing the [System Console](http://dev.px4.io/master/en/debug/system_console.html) or SWD (JTAG) debug interface.
+
+In order to access these developers would need to solder wires to the board test pads for SWD and IC to a console.
+
+
 ### Other Peripherals
 
 The wiring and configuration of other components is covered within the topics for individual [peripherals](../peripherals/README.md).


### PR DESCRIPTION
Adds link from HKPilot32 debug port info to 3DR Pixhawk 1 page - they are pretty much the same under the hood.

@davids5 Do you happen to know whether Pixfalcon has an SWD or Serial console interface? If so, do you have any imagery? No worries if not, I will just omit it for now.