### PR TITLE
Remove references to "Pixhawk" and "FMU" to be safe

### DIFF
--- a/en/flight_controller/modalai.md
+++ b/en/flight_controller/modalai.md
@@ -1,8 +1,8 @@
 # ModalAI
 
-ModalAI has a standalone flight controller based on the [Pixhawk Series](../flight_controller/pixhawk_series.md).
+ModalAI has a standalone flight controller for PX4:
 
-* [Flight Core v1](../flight_controller/modalai_fc_v1.md) - derived from the FMUv5 and FMUv5x architectures, in smaller Pixracer-style form factor, ready to be paired with [ModalAI VOXL](https://docs.modalai.com/voxl-datasheet/) for obstacle avoidance and GPS-denied navigation, or used independently as a standalone flight controller.
+* [Flight Core v1](../flight_controller/modalai_fc_v1.md) - in a smaller Pixracer-style form factor, ready to be paired with [ModalAI VOXL](https://docs.modalai.com/voxl-datasheet/) for obstacle avoidance and GPS-denied navigation, or used independently as a standalone flight controller.
 
 <!---
 

--- a/en/flight_controller/modalai_fc_v1.md
+++ b/en/flight_controller/modalai_fc_v1.md
@@ -1,6 +1,6 @@
 # ModalAI Flight Core v1
 
-The ModalAI Flight Core is a [Pixhawk Series](../flight_controller/pixhawk_series.md) derived flight controller, made in the USA. The Flight Core can be paired with [ModalAI VOXL](https://docs.modalai.com/voxl-datasheet/) for obstacle avoidance and GPS-denied navigation, or used independently as a standalone flight controller.
+The ModalAI Flight Core is a flight controller for PX4, made in the USA. The Flight Core can be paired with [ModalAI VOXL](https://docs.modalai.com/voxl-datasheet/) for obstacle avoidance and GPS-denied navigation, or used independently as a standalone flight controller.
 
 ![FlightCoreV1](../../assets/flight_controller/modalai/fc_v1/main.jpg)
 


### PR DESCRIPTION
Hi @hamishwillee, I accidentally put some references in to Pixhawk and FMU that I wasn't supposed to....  this PR removes those.