### PR TITLE
VTOL Quad - replace VT_TRANS_THR

### DIFF
--- a/en/config_vtol/vtol_quad_configuration.md
+++ b/en/config_vtol/vtol_quad_configuration.md
@@ -39,12 +39,17 @@ Getting your transition tuning right is important for obtaining a safe entry int
 
 #### Transition Throttle 
 
-Parameter: [VT_TRANS_THR](../advanced_config/parameter_reference.md#VT_TRANS_THR) <!-- deleted - replaced by VT_F_TRANS_THR ? -->
+Parameter: [VT_F_TRANS_THR](../advanced_config/parameter_reference.md#VT_F_TRANS_THR)
 
-Transition throttle defines the maximum throttle to use during the transition.
+Front transition throttle defines the target throttle for the pusher/puller motor during the front transition.
 Don’t set this too low otherwise you will never reach the transition airspeed.
-If you set it too high it will just use more power than you may want.
-For your first transition you are better off higher than lower here. 
+If your vehicle is equiped with an airspeed sensor then you can increase this parameter to make the front transition complete quicker.
+For your first transition you are better off higher than lower here.
+
+Parameter: [VT_B_TRANS_THR](../advanced_config/parameter_reference.md#VT_B_TRANS_THR)
+
+In most of the cases backtransition throttle can be set to 0 since it's not desired to produce any forward thrust.
+If the motor controller supports reverse thrust however, you can achieve this by setting a negative value.
 
 #### Forward Transition Duration
 

--- a/en/config_vtol/vtol_quad_configuration.md
+++ b/en/config_vtol/vtol_quad_configuration.md
@@ -7,7 +7,7 @@ For airframe specific documentation and build instructions see [VTOL Framebuilds
 
 1. Run *QGroundControl*
 2. Flash the master firmware
-3. In the Setup tab select the appropriate VTOL airframe, if your airframe is not listed select the Fun Cub VTOL airframe. 
+3. In the Setup tab select the appropriate VTOL airframe, if your airframe is not listed select the Fun Cub VTOL airframe.
 
 
 ### Flight / Transition Mode Switch
@@ -33,22 +33,23 @@ Follow the the respective tuning guides on how to tune multirotors and fixed win
 
 ### Transition Tuning
 
-While it might seem that you are dealing with a vehicle that can fly in two modes (multirotor for vertical takeoffs and landings and fixed wing for forwards flight) there is an additional state you also need to tune: transition. 
+While it might seem that you are dealing with a vehicle that can fly in two modes (multirotor for vertical takeoffs and landings and fixed wing for forwards flight) there is an additional state you also need to tune: transition.
 
 Getting your transition tuning right is important for obtaining a safe entry into fixed wing mode, for example, if your airspeed is too slow when it transitions it might stall.
 
-#### Transition Throttle 
+#### Transition Throttle {#transition_throttle}
 
 Parameter: [VT_F_TRANS_THR](../advanced_config/parameter_reference.md#VT_F_TRANS_THR)
 
 Front transition throttle defines the target throttle for the pusher/puller motor during the front transition.
-Don’t set this too low otherwise you will never reach the transition airspeed.
-If your vehicle is equiped with an airspeed sensor then you can increase this parameter to make the front transition complete quicker.
-For your first transition you are better off higher than lower here.
+
+This must be set high enough to ensure that the transition airspeed is reached.
+If your vehicle is equipped with an airspeed sensor then you can increase this parameter to make the front transition complete faster.
+For your first transition you are better off setting the value higher than lower.
 
 Parameter: [VT_B_TRANS_THR](../advanced_config/parameter_reference.md#VT_B_TRANS_THR)
 
-In most of the cases backtransition throttle can be set to 0 since it's not desired to produce any forward thrust.
+Generally back-transition throttle can be set to 0 since forward thrust is not (in most cases) desirable.
 If the motor controller supports reverse thrust however, you can achieve this by setting a negative value.
 
 #### Forward Transition Pusher/Puller Ramp-up Time
@@ -57,7 +58,8 @@ Parameter: [VT_PSHER_RMP_DT](../advanced_config/parameter_reference.md#VT_PSHER_
 
 A forward transition refers to the transition from multirotor to fixed wing mode.
 This is the amount of time in seconds that should be spent ramping up the throttle to the target value (defined by `VT_F_TRANS_THR`).
-A value of 0 will result in commanding the transition throttle value being set immediately. If you wish to smooth the throttling up you can increase this to a larger value, such as 3.
+A value of 0 will result in commanding the transition throttle value being set immediately.
+If you wish to smooth the throttling up you can increase this to a larger value, such as 3.
 
 Note that once the ramp up period ends throttle will be at its target setting and will remain there until (hopefully) the transition speed is reached.
 
@@ -90,7 +92,7 @@ As soon as a transition to fixed wing occurs it will be stabilised.
 Note that if you have not yet tuned your fixed wing mode you should leave this off until you are sure it behaves well in this mode.
 
 
-### Transitioning Tips {#transitioning_tips .sectionedit9}
+### Transitioning Tips {#transitioning_tips}
 
 As already mentioned make sure you have a well tuned multirotor mode.
 If during a transition something goes wrong you will switch back to this mode and it should be quite smooth.
@@ -98,7 +100,8 @@ If during a transition something goes wrong you will switch back to this mode an
 Before you fly have a plan for what you will do in each of the three phases (multirotor, transition, fixed wing) when you are in any of them and something goes wrong.
 
 Battery levels: leave enough margin for a multirotor transition for landing at the end of your flight.
-Don’t run your batteries too low as you will need more power in multirotor mode to land. Be conservative.
+Don’t run your batteries too low as you will need more power in multirotor mode to land.
+Be conservative.
 
 
 #### Transition: Getting Ready
@@ -111,25 +114,27 @@ Transition into the wind, whenever possible otherwise it will travel further fro
 Make sure the VTOL is in a stable hover before you start the transition.
 
 
-#### Transition: Multirotor to Fixed Wing (Front-transition) 
+#### Transition: Multirotor to Fixed Wing (Front-transition)
 
-Start your transition. It should transition within 50 – 100 meters.
-If it doesn’t or it isn’t flying in a stable fashion abort the transition (see below) and land or hover back to the start position and land. 
-Try increasing the transition throttle (`VT_F_TRANS_THR`) value.
-Also consider reducing the transition duration (`VT_F_TRANS_DUR`) if you are not using an airspeed sensor. If you are using an airspeed sensor
-consider lowering the transition airspeed but stay well above the stall speed.
+Start your transition.
+It should transition within 50 – 100 meters.
+If it doesn’t or it isn’t flying in a stable fashion abort the transition (see below) and land or hover back to the start position and land.
+Try increasing the [transition throttle](#transition_throttle) (`VT_F_TRANS_THR`) value.
+Also consider reducing the transition duration (`VT_F_TRANS_DUR`) if you are not using an airspeed sensor.
+If you are using an airspeed sensor consider lowering the transition airspeed but stay well above the stall speed.
 
 As soon as you notice the transition happen be ready to handle height loss which may include throttling up quickly.
 
 > **Caution** The following feature has been discussed but not implemented yet: 
-  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_F_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode. 
+  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_F_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode.
 
 
 #### Transition: Fixed Wing to Multirotor (Back-transition)
 
 When you transition back to multirotor mode bring your aircraft in on a straight level approach and reduce its speed, flip the transition switch and it will start the multirotor motors and stop the pusher/puller prop immediately and should result in a fairly smooth gliding transition.
 
-Consider that the throttle value you have when you transition will command the amount of thrust your multirotor has at the moment of the switch. Because the wing will still be flying you’ll find you have plenty of time to adjust your throttle to achieve/hold a hover.
+Consider that the throttle value you have when you transition will command the amount of thrust your multirotor has at the moment of the switch.
+Because the wing will still be flying you’ll find you have plenty of time to adjust your throttle to achieve/hold a hover.
 
 For advanced tuning of the back-transition please refer to the [Back-transition Tuning Guide](vtol_back_transition_tuning.md)
 

--- a/en/config_vtol/vtol_quad_configuration.md
+++ b/en/config_vtol/vtol_quad_configuration.md
@@ -37,21 +37,21 @@ While it might seem that you are dealing with a vehicle that can fly in two mode
 
 Getting your transition tuning right is important for obtaining a safe entry into fixed wing mode, for example, if your airspeed is too slow when it transitions it might stall.
 
-#### Transition Throttle
+#### Transition Throttle 
 
-Parameter: [VT_TRANS_THR](../advanced_config/parameter_reference.md#VT_TRANS_THR)
+Parameter: [VT_TRANS_THR](../advanced_config/parameter_reference.md#VT_TRANS_THR) <!-- deleted - replaced by VT_F_TRANS_THR ? -->
 
 Transition throttle defines the maximum throttle to use during the transition.
 Don’t set this too low otherwise you will never reach the transition airspeed.
 If you set it too high it will just use more power than you may want.
-For your first transition you are better off higher than lower here.
+For your first transition you are better off higher than lower here. 
 
 #### Forward Transition Duration
 
 Parameter: [VT_F_TRANS_DUR](../advanced_config/parameter_reference.md#VT_F_TRANS_DUR)
 
 A forward transition refers to the transition from multirotor to fixed wing mode.
-This is the amount of time in seconds that should be spent ramping up the throttle to the target value (defined by `VT_TRANS_THR`).
+This is the amount of time in seconds that should be spent ramping up the throttle to the target value (defined by `VT_TRANS_THR`).  
 A value of 0 will result in commanding the transition throttle value being set immediately. If you wish to smooth the throttling up you can increase this to a larger value, such as 3.
 
 Note that once the ramp up period ends throttle will be at its target setting and will remain there until (hopefully) the transition speed is reached.
@@ -106,17 +106,17 @@ Transition into the wind, whenever possible otherwise it will travel further fro
 Make sure the VTOL is in a stable hover before you start the transition.
 
 
-#### Transition: Multirotor to Fixed Wing (Front-transition)
+#### Transition: Multirotor to Fixed Wing (Front-transition) 
 
 Start your transition. It should transition within 50 – 100 meters.
 If it doesn’t or it isn’t flying in a stable fashion abort the transition (see below) and land or hover back to the start position and land. 
-Try increasing the transition throttle (`VT_TRANS_THR`) value. 
+Try increasing the transition throttle (`VT_TRANS_THR`) value.  
 Also consider reducing the transition duration (`VT_F_TRANS_DUR`).
 
 As soon as you notice the transition happen be ready to handle height loss which may include throttling up quickly.
 
 > **Caution** The following feature has been discussed but not implemented yet: 
-  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode.
+  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode. 
 
 
 #### Transition: Fixed Wing to Multirotor (Back-transition)

--- a/en/config_vtol/vtol_quad_configuration.md
+++ b/en/config_vtol/vtol_quad_configuration.md
@@ -51,12 +51,12 @@ Parameter: [VT_B_TRANS_THR](../advanced_config/parameter_reference.md#VT_B_TRANS
 In most of the cases backtransition throttle can be set to 0 since it's not desired to produce any forward thrust.
 If the motor controller supports reverse thrust however, you can achieve this by setting a negative value.
 
-#### Forward Transition Duration
+#### Forward Transition Pusher/Puller Ramp-up Time
 
-Parameter: [VT_F_TRANS_DUR](../advanced_config/parameter_reference.md#VT_F_TRANS_DUR)
+Parameter: [VT_PSHER_RMP_DT](../advanced_config/parameter_reference.md#VT_PSHER_RMP_DT)
 
 A forward transition refers to the transition from multirotor to fixed wing mode.
-This is the amount of time in seconds that should be spent ramping up the throttle to the target value (defined by `VT_TRANS_THR`).  
+This is the amount of time in seconds that should be spent ramping up the throttle to the target value (defined by `VT_F_TRANS_THR`).
 A value of 0 will result in commanding the transition throttle value being set immediately. If you wish to smooth the throttling up you can increase this to a larger value, such as 3.
 
 Note that once the ramp up period ends throttle will be at its target setting and will remain there until (hopefully) the transition speed is reached.
@@ -115,13 +115,14 @@ Make sure the VTOL is in a stable hover before you start the transition.
 
 Start your transition. It should transition within 50 – 100 meters.
 If it doesn’t or it isn’t flying in a stable fashion abort the transition (see below) and land or hover back to the start position and land. 
-Try increasing the transition throttle (`VT_TRANS_THR`) value.  
-Also consider reducing the transition duration (`VT_F_TRANS_DUR`).
+Try increasing the transition throttle (`VT_F_TRANS_THR`) value.
+Also consider reducing the transition duration (`VT_F_TRANS_DUR`) if you are not using an airspeed sensor. If you are using an airspeed sensor
+consider lowering the transition airspeed but stay well above the stall speed.
 
 As soon as you notice the transition happen be ready to handle height loss which may include throttling up quickly.
 
 > **Caution** The following feature has been discussed but not implemented yet: 
-  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode. 
+  Once the transition happens the multirotor motors will stop and the pusher/puller throttle will remain at the `VT_F_TRANS_THR` level until you move the throttle stick, assuming you are in manual mode. 
 
 
 #### Transition: Fixed Wing to Multirotor (Back-transition)


### PR DESCRIPTION
Hi @RomanBapst  (&/or @sanderux )

Link checker shows that `VT_TRANS_THR` disappeared at some point. Possibly replaced by `VT_F_TRANS_THR`

I've marked up the bits that are affected in the tuning guide. Can you please advise how this should "properly" change. 
There is a degree of urgency because we'll be cutting the PX4 v1.11 release soon, and it would be nice if the docs were accurate-ish at this point!