### PR TITLE
Update AUX port description in airframe_reference

### DIFF
--- a/en/airframes/airframe_reference.md
+++ b/en/airframes/airframe_reference.md
@@ -1,7 +1,7 @@
 # Airframes Reference
-> **Note** **This list is auto-generated from the source code**.
-> 
-> The **AUX** channels are only available on Pixhawk Boards (labeled with **AUX OUT**).
+> **Note**
+> **This list is auto-generated from the source code**.
+> The **AUX** channels are only available on Pixhawk compatible Boards (has labeled with **AUX OUT**/**FMU PWM OUT**).
 > 
 
 This page lists all supported airframes and types including


### PR DESCRIPTION
1. If "** **" has only one space, it will become "****" after translation.
2. Durandal、Pixhack、Cube also has AUX port. And Pixhawk4 has different label.