### PR TITLE
Lidar lite - PWM is output of sensor.

### DIFF
--- a/en/sensor/lidar_lite.md
+++ b/en/sensor/lidar_lite.md
@@ -28,7 +28,11 @@ The *Lidar-Lite v3* can be used with either PWM or I2C.
 PWM is recommended if using an older model.
 The rangefinder must be separately powered via some ESC/BEC (whether connected via PWM or I2C).
 
-> **Note** The I2C interface of non-blue-label Lidar-Lite (v1) devices has stability limitations and all silver-label generations of Lidar-Lite sensors are therefore excluded from the I2C interface. The use of the PWM interface (as detailed below) is advised for these sensors. The blue label (v2) devices can exhibit a constant offset if powered on with less than 5V under some conditions. This is currently (Q4/2015) under investigation by the manufacturer and potentially can be resolved by adhering to specific operational conditions. The recommended robust setup is a v1 device interfaced via PWM.
+> **Note** The I2C interface of non-blue-label Lidar-Lite (v1) devices has stability limitations and all silver-label generations of Lidar-Lite sensors are therefore excluded from the I2C interface.
+  The use of the PWM interface (as detailed below) is advised for these sensors.
+  The blue label (v2) devices can exhibit a constant offset if powered on with less than 5V under some conditions.
+  This is currently (Q4/2015) under investigation by the manufacturer and potentially can be resolved by adhering to specific operational conditions.
+  The recommended robust setup is a v1 device interfaced via PWM.
 
 The standard wiring instructions for Lidar-Lite 3 (from the [Operation Manual](http://static.garmin.com/pumac/LIDAR_Lite_v3_Operation_Manual_and_Technical_Specifications.pdf)) are shown below.
 Lidar-Lite v2 and v3 are the same, except that the order of pins in the connector is reversed (i.e. it is as though the connector was turned over).
@@ -38,7 +42,7 @@ Lidar-Lite v2 and v3 are the same, except that the order of pins in the connecto
 
 ### PWM Interface Wiring
 
-The pin connections for wiring LidarLite to the *Pixhawk 1* AUX ports (PWM interface) are shown below. 
+The pin connections for wiring LidarLite to the *Pixhawk 1* AUX ports (PWM interface) are shown below.
 
 Pin | Lidar-Lite (v2, v3) | Pixhawk AUX Servo | Comment
 --- | ---   | --- | ---
@@ -47,7 +51,10 @@ Pin | Lidar-Lite (v2, v3) | Pixhawk AUX Servo | Comment
 3   | PWM   | AUX 5 (bottom) | PWM output of the Lidar Lite. **Needs a 470 Ohm pull-down (to GND), Do not use a 1 K0hm resistor.**
 4   | SCL   | - | Not connected
 5   | SDA   | - | Not connected
-6   | GND   | AUX 6 (top)    | Ground
+6   | GND   | AUX 6 (top) | Ground
+
+> **Note** On a flight controller that has no AUX port the equivalent MAIN pins are used (e.g. the PWM output on the lidar instead maps to MAIN 5).
+  The pin numbers are hard-coded.
 
 The wiring for LidarLite v2 is shown below.
 Lidar-Lite v3 is wired similarly, except that the pin-numbering on the connector is reversed.

--- a/en/sensor/lidar_lite.md
+++ b/en/sensor/lidar_lite.md
@@ -44,12 +44,13 @@ Pin | Lidar-Lite (v2, v3) | Pixhawk AUX Servo | Comment
 --- | ---   | --- | ---
 1   | VCC   | AUX 6 (center) | Power supply. 4.75-5.5V DC Nominal, Maximum 6V DC.
 2   | RESET | AUX 6 (bottom) | Reset line of the sensor
-3   | PWM   | AUX 5 (bottom) | PWM input of the Lidar Lite. **Needs a 470 Ohm pull-down (to GND), Do not use a 1 K0hm resistor.**
+3   | PWM   | AUX 5 (bottom) | PWM output of the Lidar Lite. **Needs a 470 Ohm pull-down (to GND), Do not use a 1 K0hm resistor.**
 4   | SCL   | - | Not connected
 5   | SDA   | - | Not connected
 6   | GND   | AUX 6 (top)    | Ground
 
-The wiring for LidarLite v2 is shown below. Lidar-Lite v3 is wired similarly, except that the pin-numbering on the connector is reversed.
+The wiring for LidarLite v2 is shown below.
+Lidar-Lite v3 is wired similarly, except that the pin-numbering on the connector is reversed.
 
 ![Lidar Lite 2 Interface wiring](../../assets/hardware/sensors/lidar_lite/lidar_lite_2_interface_wiring.jpg)
 
@@ -67,7 +68,8 @@ TBD
 
 The rangefinder/port is enabled using [SENS_EN_LL40LS](../advanced_config/parameter_reference.md#SENS_EN_LL40LS) - set to `1` for PWM, or `2` for I2C.
 
-> **Tip** The driver for this rangefinder is usually present in firmware. If missing, you would also need to add the driver (`drivers/ll40ls`) to the board configuration.
+> **Tip** The driver for this rangefinder is usually present in firmware.
+  If missing, you would also need to add the driver (`drivers/ll40ls`) to the board configuration.
 
 ## Further Information
 

--- a/en/sensor/lidar_lite.md
+++ b/en/sensor/lidar_lite.md
@@ -68,7 +68,8 @@ Lidar-Lite v3 is wired similarly, except that the pin-numbering on the connector
 
 ### I2C Interface Wiring
 
-TBD
+The I2C wiring is the same for any other distance sensor.
+Simply connect the SLA, SLC, GND and VCC to the corresponding (same) pins on the flight controller and the sensor.
 
 
 ## Software Configuration


### PR DESCRIPTION
This fixes the label on the data connection between Pixhawk AUX5 and the Lidarlite PWM output (to say that it is an output and not an input).

@bkueng Almost all the docs we have refer to using Pixhawk PWM ports as outputs, but this is a case where we specify it is an input. Some general questions, mostly FMI:
1. Would this be hard-coded to use only this port, and if so, does this mean you couldn't use lidarlite on a board that did not have an IO board?
1. How does this work with mixers? i.e. how does PX4 know that this is an input? How is confict resolved?
1. Do we need a topic "PWM ports as inputs" :-) ?