### PR TITLE
Fix mRo Pixhawk hardware version in SUMMARY

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -195,7 +195,7 @@
     * [mRo Pixracer (FMUv4)](flight_controller/pixracer.md)
     * [Hex Cube Black (FMUv3)](flight_controller/pixhawk-2.md)
     * [CUAV Pixhack v3 (FMUv3)](flight_controller/pixhack_v3.md)
-    * [mRo Pixhawk (FMUv2)](flight_controller/mro_pixhawk.md)
+    * [mRo Pixhawk (FMUv3)](flight_controller/mro_pixhawk.md)
   * [Manufacturer-Supported Autopilots](flight_controller/autopilot_manufacturer_supported.md)
     * [AirMind MindPX](flight_controller/mindpx.md)
     * [AirMind MindRacer](flight_controller/mindracer.md)


### PR DESCRIPTION
Referenced the content: https://docs.px4.io/master/en/flight_controller/mro_pixhawk.html
> The main difference is that it(mRo Pixhawk) is based on the Pixhawk-project FMUv3 open hardware design.