### PR TITLE
Add GPS fix type 4, GNSS + Dead Reckoning

### DIFF
--- a/en/log/flight_review.md
+++ b/en/log/flight_review.md
@@ -251,7 +251,7 @@ The *GPS Uncertainty* plot shows information from the GPS device:
 - Number of used satellites (should be around 12 or higher)
 - Horizontal position accuracy (should be below 1 meter)
 - Vertical position accuracy (should be below 2 meters)
-- GPS fix: this is 3 for a 3D GPS fix, 5 for RTK float and 6 for RTK fixed type
+- GPS fix: this is 3 for a 3D GPS fix, 4 for GPS + Dead Reckoning, 5 for RTK float and 6 for RTK fixed type
 
 
 ## GPS Noise & Jamming


### PR DESCRIPTION
As per https://discuss.px4.io/t/gps-fix-shows-as-3-or-4-but-only-3-5-6-are-valid/17496/2