### PR TITLE
Camera capture - add info about CAM_CAP_FBACK

### DIFF
--- a/en/peripherals/camera.md
+++ b/en/peripherals/camera.md
@@ -33,6 +33,8 @@ Mode | Description
 
 ## Trigger Hardware Configuration {#hardware_setup}
 
+### Camera Triggering
+
 The pins used to trigger image capture for GPIO, PWM or Seagull-based triggering (i.e. when not using a MAVLink camera) are set using the [TRIG_PINS](../advanced_config/parameter_reference.md#TRIG_PINS) parameter.
 The default is 56, which means that trigger is enabled on *FMU* pins 5 and 6.
 
@@ -44,10 +46,16 @@ The default is 56, which means that trigger is enabled on *FMU* pins 5 and 6.
 > **Warning** With `TRIG_PINS=56` (default) you can use the AUX pins 1 to 4 as actuator outputs (for servos/ESCs).
   With `TRIG_PINS=78`, you can use the AUX pins 1-6 as actuator outputs.
   Any other combination of pins can be selected, but this will disable use of the other FMU pins as outputs.
-  
+
+### Camera Capture
+
 Some cameras can provide image capture signalling to a flight controller camera-capture pin (this enables more accurate image timestamp than the time that the trigger command is sent).
+Camera capture/feedback is enabled by setting [CAM_CAP_FBACK = 1](../advanced_config/parameter_reference.md#CAM_CAP_FBACK).
+
+The pin used depends on the hardware:
 - Pixhawk FMUv5x boards use the board-specific camera capture pin (PI0).
 - Other board use FMU PWM pin 6 (hardcoded) for camera capture.
+
  
 > **Note** PX4 emits the MAVLink [CAMERA_TRIGGER](https://mavlink.io/en/messages/common.html#CAMERA_TRIGGER) message (with timestamp and image sequence number).
   If camera capture is configured, the timestamp from the camera capture driver is used, otherwise the triggering timestamp.


### PR DESCRIPTION
Follows on from https://github.com/PX4/Firmware/issues/15526#issuecomment-679008693

@bkueng This adds info about parameter for enabling camera feedback. There is another question outstanding somewhere about signal requirements/how this is wired (ie we know what pin to use, but can we just wire the hotshoe up) - I have no idea how this works, so can't comment.
We would include that in the "camera capture" section, but perhaps merge this first.