### PR TITLE
Add instructions for gliding setpoint

### DIFF
--- a/en/flight_modes/offboard.md
+++ b/en/flight_modes/offboard.md
@@ -57,11 +57,14 @@ The action is defined in the parameters [COM_OBL_ACT](#COM_OBL_ACT) and [COM_OBL
 
 * [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED)
   * The following input combinations are supported (via `type_mask`): <!-- https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp#L166-L170 -->
-    * Position setpoint (only `x`, `y`, `z`)
+    * Position setpoint (`x`, `y`, `z` only; velocity and acceleration setpoints are ignored).
       * Specify the *type* of the setpoint in `type_mask` (if these bits are not set the vehicle will fly in a flower-like pattern):
-        > **Note** The *setpoint type* values below are not part of the MAVLink standard for the `type_mask` field.
+        > **Note** Some of the *setpoint type* values below are not part of the MAVLink standard for the `type_mask` field.
 
         The values are:
+        - 292: Gliding setpoint.
+          This configures TECS to prioritize airspeed over altitude in order to make the vehicle glide when there is no thrust (i.e. pitch is controlled to regulate airspeed).
+          It is equivalent to setting `type_mask` as `POSITION_TARGET_TYPEMASK_Z_IGNORE`, `POSITION_TARGET_TYPEMASK_VZ_IGNORE`, `POSITION_TARGET_TYPEMASK_AZ_IGNORE`. 
         - 4096: Takeoff setpoint.
         - 8192: Land setpoint.
         - 12288: Loiter setpoint (fly a circle centred on setpoint).


### PR DESCRIPTION
This adds the instructions to enable offboard gliding setpoints for fixed wing vehicles.

The feature was added in https://github.com/PX4/Firmware/pull/14643