### PR TITLE
Remove explicit anchors from headings

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -58,7 +58,8 @@ In order to use new sensors, or if you have made changes that significantly affe
 - [PX4 Developer Guide](http://dev.px4.io/) explains how to modify flight algorithms, add new modes, integrate new hardware, communicate with PX4 from outside the flight controller, and contribute to PX4.
 
 
-## Forums and Chat {#support}
+<span id="support"></span>
+## Forums and Chat
 
 The core development team and community are active on the following forums and chat channels:
 

--- a/en/advanced_config/bootloader_update.md
+++ b/en/advanced_config/bootloader_update.md
@@ -7,8 +7,8 @@ This topic explains several methods for updating the Pixhawk bootloader.
 > **Note** Hardware usually comes with an appropriate bootloader version pre-installed.
   A case where you may need to update is newer Pixhawk boards that install FMUv2 firmware: [Firmware > FMUv2 Bootloader Update](../config/firmware.md#bootloader).
 
-
-## QGroundControl Bootloader Update {#qgc_bootloader_update}
+<span id="qgc_bootloader_update"></span>
+## QGroundControl Bootloader Update
 
 The easiest approach is to first use *QGroundControl* to install firmware with the desired/latest bootloader. 
 You can then initiate bootloader update on next restart by setting the parameter: [SYS_BL_UPDATE](../advanced_config/parameter_reference.md#SYS_BL_UPDATE).
@@ -31,7 +31,8 @@ The steps are:
 Generally at this point you may then want to [update the firmware](../config/firmware.md) again using the correct/newly installed bootloader.
 
 
-### Dronecode Probe Bootloader Update {#dronecode_probe}
+<span id="dronecode_probe"></span>
+### Dronecode Probe Bootloader Update
 
 The following steps explain how you can "manually" update the bootloader using the dronecode probe:
 
@@ -80,7 +81,8 @@ Reading symbols from px4fmuv5_bl.elf...done.
 
 After the bootloader has updated you can [Load PX4 Firmware](../config/firmware.md) using *QGroundControl*.
 
-## Other Boards (Non-Pixhawk) {#non-pixhawk}
+<span id="non-pixhawk"></span>
+## Other Boards (Non-Pixhawk)
 
 Boards that are not part of the [Pixhawk Series](../flight_controller/pixhawk_series.md) will have their own mechanisms for bootloader update.
 

--- a/en/advanced_config/bootloader_update_from_betaflight.md
+++ b/en/advanced_config/bootloader_update_from_betaflight.md
@@ -4,7 +4,8 @@ This page documents how to flash the PX4 bootloader onto boards preflashed with 
 
 There are two options for flashing the bootloader: via *Betaflight Configurator* (easier), or building from source.
 
-### Bootloader Update using Betaflight Configurator {#betaflight_configurator}
+<span id="betaflight_configurator"></span>
+### Bootloader Update using Betaflight Configurator
 
 To install the PX4 bootloader using the *Betaflight Configurator*:
 1. You should have downloaded already the pre-built bootloader binary (this depends on the board you want to flash).
@@ -58,7 +59,8 @@ See the dfuse manual here: https://www.st.com/resource/en/user_manual/cd00155676
 Flash the **<target>.bin** file.
 
 
-## Reinstall Betaflight {#reinstall_betaflight}
+<span id="reinstall_betaflight"></span>
+## Reinstall Betaflight
 
 In order to switch back to *Betaflight*:
 - Backup the PX4 parameters, e.g. by [exporting](https://dev.px4.io/master/en/advanced/parameters_and_configurations.html#exporting-and-loading-parameters) them to an SD card

--- a/en/advanced_config/compass_power_compensation.md
+++ b/en/advanced_config/compass_power_compensation.md
@@ -9,7 +9,8 @@ This topic explains how to compensate for the induced magnetic fields in the cas
 <span></span>
 > **Note** The process is demonstrated for a multicopter, but is equally valid for other vehicle types.
 
-## When is Power Compensation Applicable? {#when}
+<span id="when"></span>
+## When is Power Compensation Applicable?
 
 Performing this power compensation is advisable only if all the following statements are true:
 1. The compass cannot be moved away from the power-carrying cables.
@@ -18,7 +19,8 @@ Performing this power compensation is advisable only if all the following statem
    
 1. The drone cables are all fixed in place/do not move (calculated compensation parameters will be invalid if the current-carrying cables can move).
 
-## How to Compensate the Compass {#how}
+<span id="how"></span>
+## How to Compensate the Compass
 
 1. Make sure your drone runs a Firmware version supporting power compensation (current master, or releases from v.1.11.0).
 1. Perform the [standard compass calibration](../config/compass.md#compass-calibration).

--- a/en/advanced_config/land_detector.md
+++ b/en/advanced_config/land_detector.md
@@ -39,7 +39,8 @@ These two parameters are sometimes worth tuning:
   This parameter can be adjusted to ensure land detection triggers earlier or later on throwing the airframe for hand-launches.
 
 
-## Land Detector States {#states}
+<span id="states"></span>
+## Land Detector States
 
 ### Multicopter Land Detection
 

--- a/en/advanced_config/parameters.md
+++ b/en/advanced_config/parameters.md
@@ -12,7 +12,8 @@ The screen is accessed by clicking the top menu *Gear* icon and then *Parameters
 > **Warning** While some parameters can be changed in flight, this is not recommended (except where explicitly stated in the guide).
 
 
-## Finding a Parameter {#finding}
+<span id="finding"></span>
+## Finding a Parameter
 
 You can search for a parameter by entering a term in the *Search* field.
 This will show you a list of all parameter names and descriptions that contain the entered substring (press **Clear** to reset the search).
@@ -26,7 +27,8 @@ You can also browse the parameters by group by clicking on the buttons to the le
 > **Tip** If you can't find an expected parameter, see the [next section](#missing).
 
 
-## Missing Parameters {#missing}
+<span id="missing"></span>
+## Missing Parameters
 
 Parameters are usually not visible because either they are conditional on other parameters, or they are not present in the firmware (see below).
 
@@ -64,7 +66,8 @@ There are two options to solve this problem:
     Finding modules to remove requires some trial/error and depends on what use cases you need the vehicle to meet.
 
 
-## Changing a Parameter {#changing}
+<span id="changing"></span>
+## Changing a Parameter
 
 To change the value of a parameter click on the parameter row in a group or search list.
 This will open a side dialog in which you can update the value (this dialog also provides additional detailed information about the parameter - including whether a reboot is required for the change to take effect).

--- a/en/advanced_config/prearm_arm_disarm.md
+++ b/en/advanced_config/prearm_arm_disarm.md
@@ -18,7 +18,8 @@ PX4 allows you to configure how pre-arming, arming and disarming work using para
 
 > **Note** Arming/disarming parameters can be found in [Parameter Reference > Commander](../advanced_config/parameter_reference.md#commander) (search for `COM_ARM_` and `COM_DISARM_*`).
 
-## Arming Gesture {#arm_disarm_gestures}
+<span id="arm_disarm_gestures"></span>
+## Arming Gesture
 
 By default, the vehicle is armed and disarmed by moving RC throttle/yaw sticks to particular extremes and holding them for 1 second.
 - **Arming:** Throttle minimum, yaw maximum
@@ -38,7 +39,8 @@ Parameter | Description
 --- | ---
 <span id="COM_RC_ARM_HYST"></span>[COM_RC_ARM_HYST](../advanced_config/parameter_reference.md#COM_RC_ARM_HYST) | Time that RC stick must be held in arm/disarm position before arming/disarming occurs (default: 1 second).
 
-## Arming Button/Switch {#arm_disarm_switch}
+<span id="arm_disarm_switch"></span>
+## Arming Button/Switch
 
 An *arming button* or "momentary switch" can be configured to trigger arm/disarm *instead* of [gesture-based arming](#arm_disarm_gestures) (setting an arming switch disables arming gestures).
 The button should be held down for ([nominally](#COM_RC_ARM_HYST)) one second to arm (when disarmed) or disarm (when armed).

--- a/en/advanced_config/sensor_thermal_calibration.md
+++ b/en/advanced_config/sensor_thermal_calibration.md
@@ -7,7 +7,8 @@ This topic details the [test environment](#test_setup) and [calibration procedur
 > **Note** At time of writing (June2019/PX4 v1.9) thermal calibration of the magnetometer is not yet supported.
 
 
-## Test Setup/Best Practice {#test_setup}
+<span id="test_setup"></span>
+## Test Setup/Best Practice
 
 The [calibration procedures](#calibration_procedures) described in the following sections are ideally run in an *environment chamber* (a temperature and humidity controlled environment) as the board is heated from the lowest to the highest operating/calibration temperature. Before starting the calibration, the board is first *cold soaked* (cooled to the minimum temperature and allowed to reach equilibrium).
 
@@ -29,7 +30,8 @@ If in doubt, check the safe operating range with your manufacturer.
 > **Tip** To check the status of the onboard thermal calibration use the MAVlink console (or NuttX console) to check the reported internal temp from the sensor. 
 
 
-## Calibration Procedures {#calibration_procedures}
+<span id="calibration_procedures"></span>
+## Calibration Procedures
 
 PX4 supports two calibration procedures: 
 * [onboard](#onboard_calibration) - calibration is run on the board itself. This method requires knowledge of the amount of temperature rise that is achievable with the test setup.
@@ -38,7 +40,8 @@ PX4 supports two calibration procedures:
 The offboard approach is more complex and slower, but requires less knowledge of the test setup and is easier to validate. 
 
 
-### Onboard Calibration Procedure {#onboard_calibration}
+<span id="onboard_calibration"></span>
+### Onboard Calibration Procedure
 
 Onboard calibration is run entirely on the device. It require knowledge of the amount of temperature rise that is achievable with the test setup. 
 
@@ -55,7 +58,8 @@ To perform and onboard calibration:
 9. Perform a 6-point accel calibration via the system console using `commander calibrate accel` or via *QGroundControl*. If the board is being set-up for the first time, the gyro and magnetometer calibration will also need to be performed.
 8. The board should always be re-powered before flying after any sensor calibration, because sudden offset changes from calibration can upset the navigation estimator and some parameters are not loaded by the algorithms that use them until the next startup. 
 
-### Offboard Calibration Procedure {#offboard_calibration}
+<span id="offboard_calibration"></span>
+### Offboard Calibration Procedure
 
 Offboard calibration is run on a development computer using data collected during the calibration test. This method provides a way to visually check the quality of data and curve fit.
 
@@ -79,7 +83,8 @@ To perform an offboard calibration:
 1. Power the board and perform a normal accelerometer sensor calibration using *QGroundControl*. It is important that this step is performed when board is within the calibration temperature range. The board must be repowered after this step before flying as the sudden offset changes can upset the navigation estimator and some parameters are not loaded by the algorithms that use them until the next startup.
 
 
-## Implementation Detail {#implementation}
+<span id="implementation"></span>
+## Implementation Detail
 
 Calibration refers to the process of measuring the change in sensor value across a range of internal temperatures, and performing a polynomial fit on the data to calculate a set of coefficients (stored as parameters) that can be used to correct the sensor data. Compensation refers to the process of using the internal temperature to calculate an offset that is subtracted from the sensor reading to correct for changing offset with temperature
 

--- a/en/advanced_config/tuning_the_ecl_ekf.md
+++ b/en/advanced_config/tuning_the_ecl_ekf.md
@@ -103,13 +103,15 @@ GPS measurements will be used for position and velocity if the following conditi
   These checks are controlled by the [EKF2_GPS_CHECK](../advanced_config/parameter_reference.md#EKF2_GPS_CHECK) and `EKF2_REQ_*` parameters.
 * GPS height can be used directly by the EKF via setting of the [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) parameter.
 
-#### Yaw Measurements {#yaw_measurements}
+<span id="yaw_measurements"></span>
+#### Yaw Measurements
 
 Some GPS receivers such as the [Trimble MB-Two RTK GPS receiver](https://www.trimble.com/Precision-GNSS/MB-Two-Board.aspx) can be used to provide a heading measurement that replaces the use of magnetometer data.
 This can be a significant advantage when operating in an environment where large magnetic anomalies are present, or at latitudes here the earth's magnetic field has a high inclination.
 Use of GPS yaw measurements is enabled by setting bit position 7 to 1 (adding 128) in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter.
 
-#### Yaw From GPS Velocity {#yaw_from_gps_velocity}
+<span id="yaw_from_gps_velocity"></span>
+#### Yaw From GPS Velocity
 
 The EKF runs an additional multi-hypothesis filter internally that uses multiple 3-state Extended Kalman Filters (EKF's) whose states are NE velocity and yaw angle.
 These individual yaw angle estimates are then combined using a Gaussian Sum Filter (GSF). The individual 3-state EKF's use IMU and GPS horizontal velocity data (plus optional airspeed data) and do not rely on any prior knowledge of the yaw angle or magnetometer measurements.
@@ -190,7 +192,8 @@ Airspeed data will be used when it exceeds the threshold set by a positive value
 Fixed wing platforms can take advantage of an assumed sideslip observation of zero to improve wind speed estimation and also enable wind speed estimation without an airspeed sensor.
 This is enabled by setting the [EKF2_FUSE_BETA](../advanced_config/parameter_reference.md#EKF2_FUSE_BETA) parameter to 1.
 
-### Multicopter Wind Estimation using Drag Specific Forces {#mc_wind_estimation_using_drag}
+<span id="mc_wind_estimation_using_drag"></span>
+### Multicopter Wind Estimation using Drag Specific Forces
 
 Multi-rotor platforms can take advantage of the relationship between airspeed and drag force along the X and Y body axes to estimate North/East components of wind velocity.
 This is enabled by setting bit position 5 in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter to true.
@@ -211,7 +214,8 @@ Optical flow data will be used if the following conditions are met:
 * Bit position 1 in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter is true.
 * The quality metric returned by the flow sensor is greater than the minimum requirement set by the [EKF2_OF_QMIN](../advanced_config/parameter_reference.md#EKF2_OF_QMIN) parameter.
 
-### External Vision System {#ekf2_extvis}
+<span id="ekf2_extvis"></span>
+### External Vision System
 
 Position, velocity or orientation measurements from an external vision system, e.g. Vicon, can be used:
 

--- a/en/advanced_features/precland.md
+++ b/en/advanced_features/precland.md
@@ -78,7 +78,8 @@ commander mode auto:precland
 ```
 In this case, the precision landing is always considered "required".
 
-### In a Mission {#mission}
+<span id="mission"></span>
+### In a Mission
 
 Precision landing can be initiated as part of a [mission](../flying/missions.md) using [MAV_CMD_NAV_LAND](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND) with `param2` set appropriately:
 

--- a/en/advanced_features/traffic_avoidance_adsb.md
+++ b/en/advanced_features/traffic_avoidance_adsb.md
@@ -4,7 +4,8 @@ PX4 can use [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillan
 If a potential collision is detected, PX4 can *warn*, immediately [land](../flight_modes/land.md), or [return](../flight_modes/return.md) (depending on the value of [NAV_TRAFF_AVOID](#NAV_TRAFF_AVOID)).
 
 
-## Supported Hardware {#supported_hardware}
+<span id="supported_hardware"></span>
+## Supported Hardware
 
 PX4 traffic avoidance works with ADS-B or FLARM products that supply transponder data using the MAVLink [ADSB_VEHICLE](https://mavlink.io/en/messages/common.html#ADSB_VEHICLE) message.
 

--- a/en/advanced_features/traffic_avoidance_utm.md
+++ b/en/advanced_features/traffic_avoidance_utm.md
@@ -18,7 +18,8 @@ Parameter | Description
 <span id="NAV_TRAFF_A_RADU"></span>[NAV_TRAFF_A_RADU](../advanced_config/parameter_reference.md#NAV_TRAFF_A_RADU) | Set traffic avoidance trigger distance for *unmanned* aviation
 
 
-## Implementation {#implementation}
+<span id="implementation"></span>
+## Implementation
 
 PX4 listens for `UTM_GLOBAL_POSITION` MAVLink messages during missions.
 When a valid message is received, its validity flags, position and heading are mapped into the same `transponder_report` UORB topic used for *ADS-B traffic avoidance*.

--- a/en/assembly/quick_start_cuav_v5_nano.md
+++ b/en/assembly/quick_start_cuav_v5_nano.md
@@ -102,7 +102,8 @@ The other radio is connected to your ground station computer or mobile device (u
 ![quickstart](../../assets/flight_controller/cuav_v5_nano/connection/v5_nano_quickstart_07.png)
 
 
-## SD Card (Optional) {#sd_card}
+<span id="sd_card"></span>
+## SD Card (Optional)
 
 An [SD card](../getting_started/px4_basic_concepts.md#sd_cards) is inserted in the factory (you do not need to do anything).
 

--- a/en/assembly/quick_start_cuav_v5_plus.md
+++ b/en/assembly/quick_start_cuav_v5_plus.md
@@ -95,7 +95,8 @@ The other radio is connected to your ground station computer or mobile device (u
 
 ![V5+ AutoPilot](../../assets/flight_controller/cuav_v5_plus/connection/v5+_quickstart_06.png)
 
-## SD Card (Optional) {#sd_card}
+<span id="sd_card"></span>
+## SD Card (Optional)
 
 An [SD card](../getting_started/px4_basic_concepts.md#sd_cards) is inserted in the factory (you do not need to do anything).
 
@@ -106,7 +107,8 @@ Motors/servos are connected to the MAIN and AUX ports in the order specified for
 ![V5+ AutoPilot](../../assets/flight_controller/cuav_v5_plus/connection/v5+_quickstart_07.png)
 
 
-## Pinouts {#pinouts}
+<span id="pinouts"></span>
+## Pinouts
 
 Download **V5+** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).
 

--- a/en/assembly/quick_start_cube.md
+++ b/en/assembly/quick_start_cube.md
@@ -52,7 +52,8 @@ Customized screws are supposed to be M2.5 with thread length inside Cube in rang
 ![Cube Mount - Mounting Plate](../../assets/flight_controller/cube/cube_mount_plate_screws.jpg)
 
 
-## GPS + Compass + Safety Switch + LED {#gps}
+<span id="gps"></span>
+## GPS + Compass + Safety Switch + LED
 
 The recommended GPS modules are the *Here* and [Here+](../gps_compass/rtk_gps_hex_hereplus.md), both of which incorporate a GPS module, Compass, Safety Switch and [LEDs](../getting_started/led_meanings.md).
 
@@ -71,7 +72,8 @@ The diagram below shows a schematic view of the module and its connections.
 > **Tip** If you want to use an old-style 6-pin GPS module, the kit comes with a cable that you can use to connect both the GPS and [Safety Switch](#safety_switch).
 
 
-## Safety Switch {#safety_switch}
+<span id="safety_switch"></span>
+## Safety Switch
 
 The *dedicated* safety switch that comes with the Cube is only required if you are not using the recommended [GPS](#gps) (which has an inbuilt safety switch).
 
@@ -86,7 +88,8 @@ This should be connected to the USB port as shown (no further configuration is r
 ![Cube Buzzer](../../assets/flight_controller/cube/cube_buzzer.jpg)
 
 
-## Radio Control {#rc_control}
+<span id="rc_control"></span>
+## Radio Control
 
 A [remote control (RC) radio system](../getting_started/rc_transmitter_receiver.md) is required if you want to *manually* control your vehicle (PX4 does not require a radio system for autonomous flight modes). 
 
@@ -116,7 +119,8 @@ which may be purchased from hex.aero or proficnc.com.
 
 
 
-## Power {#power}
+<span id="power"></span>
+## Power
 
 Cube is typically powered from a Lithium Ion Polymer (LiPo) Battery via a Power Module (supplied with the kit) that is connected to the **POWER1** port.
 The power module provides reliable supply and voltage/current indication to the board and may separately supply power to ESCs that are used to drive motors on a multicopter vehicle. 
@@ -128,7 +132,8 @@ A typical power setup for a Multicopter vehicle is shown below.
 
 <!-- HOw is the power rail powered for servos - power rail? Plane/Vtol would be cool to show here too -->
 
-## Telemetry System (Optional) {#telemetry}
+<span id="telemetry"></span>
+## Telemetry System (Optional)
 
 A telemetry system allows you to communicate with, monitor, and control a vehicle in flight from a ground station (for example, you can direct the UAV to a particular position, or upload a new mission).
 

--- a/en/assembly/quick_start_cube.md
+++ b/en/assembly/quick_start_cube.md
@@ -118,8 +118,6 @@ PWM receivers must therefore connect to the **RCIN** port *via* a PPM encoder mo
 which may be purchased from hex.aero or proficnc.com.
 
 
-
-<span id="power"></span>
 ## Power
 
 Cube is typically powered from a Lithium Ion Polymer (LiPo) Battery via a Power Module (supplied with the kit) that is connected to the **POWER1** port.

--- a/en/assembly/quick_start_durandal.md
+++ b/en/assembly/quick_start_durandal.md
@@ -48,12 +48,14 @@ The GPS/Compass should be mounted on the frame as far away from other electronic
   You can press the safety switch again to enable safety and disarm the vehicle (this can be useful if, for whatever reason, you are unable to disarm the vehicle from your remote control or ground station).
 
 
-## Power {#power}
+<span id="power"></span>
+## Power
 
 You can use a power module or power distribution board to power motors/servos and measure power consumption.
 The recommended power modules are shown below.
 
-### PM02 v3 Power Module {#pm02_v3}
+<span id="pm02_v3"></span>
+### PM02 v3 Power Module
 
 The [Power Module (PM02 v3)](https://shop.holybro.com/power-modulepm02-v3_p1185.html) can be bundled with *Durandal*.
 It provides regulated power to flight controller and sends battery voltage/current to the flight controller.
@@ -86,7 +88,8 @@ The power module has the following characteristics/limits:
 
 > **Note** See also [PM02v3 Power Module Manual](http://www.holybro.com/manual/Holybro_PM02_v3_PowerModule_Manual.pdf) (Holybro).
 
-### Pixhawk 4 Power Module (PM07) {#pm07}
+<span id="pm07"></span>
+### Pixhawk 4 Power Module (PM07)
 
 The [Pixhawk 4 Power Module (PM07)](https://shop.holybro.com/pixhawk-4-power-module-pm07_p1095.html) can be bundled/used with *Durandal*.
 It acts as both a power module and power distribution board, providing regulated power to flight controller and the ESCs, and sending battery voltage/current to the flight controller. 
@@ -178,7 +181,8 @@ The wiring and configuration of optional/less common components is covered withi
 
 [Durandal > Pinouts](../flight_controller/durandal.md#pinouts)
 
-## PX4 Configuration {#configuration}
+<span id="configuration"></span>
+## PX4 Configuration
 
 First you will need to install [PX4 "Master" Firmware](../config/firmware.md#custom) onto the controller using *QGroundControl*.
 > **Note** Durandal support will be in the *stable* PX4 release that follows PX4 v1.10.

--- a/en/assembly/quick_start_durandal.md
+++ b/en/assembly/quick_start_durandal.md
@@ -48,7 +48,6 @@ The GPS/Compass should be mounted on the frame as far away from other electronic
   You can press the safety switch again to enable safety and disarm the vehicle (this can be useful if, for whatever reason, you are unable to disarm the vehicle from your remote control or ground station).
 
 
-<span id="power"></span>
 ## Power
 
 You can use a power module or power distribution board to power motors/servos and measure power consumption.

--- a/en/assembly/quick_start_holybro_pix32_v5.md
+++ b/en/assembly/quick_start_holybro_pix32_v5.md
@@ -47,7 +47,6 @@ The GPS/Compass should be mounted on the frame as far away from other electronic
   To disable the safety press and hold the safety switch for 1 second.
   You can press the safety switch again to enable safety and disarm the vehicle (this can be useful if, for whatever reason, you are unable to disarm the vehicle from your remote control or ground station).
 
-<span id="power"></span>
 ## Power
 
 You can use a power module or power distribution board to power motors/servos and measure power consumption.

--- a/en/assembly/quick_start_holybro_pix32_v5.md
+++ b/en/assembly/quick_start_holybro_pix32_v5.md
@@ -47,12 +47,14 @@ The GPS/Compass should be mounted on the frame as far away from other electronic
   To disable the safety press and hold the safety switch for 1 second.
   You can press the safety switch again to enable safety and disarm the vehicle (this can be useful if, for whatever reason, you are unable to disarm the vehicle from your remote control or ground station).
 
-## Power {#power}
+<span id="power"></span>
+## Power
 
 You can use a power module or power distribution board to power motors/servos and measure power consumption.
 The recommended power modules are shown below.
 
-### PM02 v3 Power Module {#pm02_v3}
+<span id="pm02_v3"></span>
+### PM02 v3 Power Module
 
 The [Power Module (PM02 v3)](https://shop.holybro.com/power-modulepm02-v3_p1185.html) can be bundled with *pix32 v5*.
 It provides regulated power to flight controller and sends battery voltage/current to the flight controller.

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -134,7 +134,8 @@ The vehicle-based radio should be connected to the **TELEM1** port as shown belo
 ![Pixhawk 4/Telemetry Radio](../../assets/flight_controller/pixhawk4/pixhawk4_telemetry_radio.jpg)
 
 
-## SD Card (Optional) {#sd_card}
+<span id="sd_card"></span>
+## SD Card (Optional)
 
 SD cards are highly recommended as they are needed to [log and analyse flight details](../getting_started/flight_reporting.md), to run missions, and to use UAVCAN-bus hardware.
 Insert the card (included in Pixhawk 4 kit) into *Pixhawk 4* as shown below.

--- a/en/complete_vehicles/intel_aero.md
+++ b/en/complete_vehicles/intel_aero.md
@@ -157,7 +157,8 @@ After setting up the PX4 development environment, follow these steps update the 
    ./Tools/mavlink_shell.py 0.0.0.0:14550
    ```
 
-## Connecting LeddarOne Range Finder {#leddarone}
+<span id="leddarone"></span>
+## Connecting LeddarOne Range Finder
 
 Connect the [LeddarOne](../sensor/leddar_one.md) to the Aero telemetry port.
 The pinout for the LeddarOne and Aero telemetry port (TELEM1) are as follows.
@@ -173,7 +174,8 @@ The pinout for the LeddarOne and Aero telemetry port (TELEM1) are as follows.
 
 To enable the rangefinder set the [SENS_LEDDAR1_CFG](../advanced_config/parameter_reference.md#SENS_LEDDAR1_CFG) parameter to TELEM1 and reboot the board (instructions for setting parameters [available here](../advanced_config/parameters.md)).
 
-## Connecting Lidar Lite Range Finder {#lidar_lite}
+<span id="lidar_lite"></span>
+## Connecting Lidar Lite Range Finder
 
 > **Warning** The Lidar Lite is not recommended for use with *Intel Aero Ready to Fly Drone*® due to measurements spikes.
 

--- a/en/complete_vehicles/px4_vision_kit.md
+++ b/en/complete_vehicles/px4_vision_kit.md
@@ -139,7 +139,8 @@ In addition, users will need ground station hardware/software:
      ![Propeller nuts](../../assets/hardware/px4_vision_devkit/propeller_nuts.jpg)
 
 
-## Fly the Drone (with avoidance) {#fly_drone}
+<span id="fly_drone"></span>
+## Fly the Drone (with avoidance)
 
 
 When the vehicle setup described above is complete:
@@ -187,7 +188,8 @@ PX4 and the companion computer exchange data over [MAVLink](https://mavlink.io/e
 - [Collision Prevention Interface](../computer_vision/collision_prevention.md) - API for vehicle based avoidance in manual position mode based on an obstacle map (currently used for collision prevention).
 
 
-### Installing the image on the Companion Computer {#install_image_mission_computer}
+<span id="install_image_mission_computer"></span>
+### Installing the image on the Companion Computer
 
 You can install the image on the *UP Core* and boot from internal memory (instead of the USB stick).
 
@@ -213,7 +215,8 @@ To flash the USB image to the *UP Core*:
    The *UP Core* computer will now boot from internal memory (eMMC).
 
 
-### Boot the Companion Computer {#boot_mission_computer}
+<span id="boot_mission_computer"></span>
+### Boot the Companion Computer
 
 First insert the provided USB2.0 stick into the *UP Core* port labeled `USB1`, and then power the vehicle using a 4S battery.
 The avoidance system should start within about 1 minute (though this does depend on the USB stick supplied).
@@ -226,7 +229,8 @@ The avoidance system should be up and running within around 30 seconds.
 Once started the companion computer can be used both as a computer vision development environment and for running the software.
 
 
-### Login to the Companion Computer {#login_mission_computer}
+<span id="login_mission_computer"></span>
+### Login to the Companion Computer
 
 To login to the companion computer:
 1. Connect a keyboard and mouse to the *UP Core* via port `USB2`:

--- a/en/computer_vision/collision_prevention.md
+++ b/en/computer_vision/collision_prevention.md
@@ -44,7 +44,8 @@ Parameter | Description
 <span id="CP_GO_NO_DATA"></span>[CP_GO_NO_DATA](../advanced_config/parameter_reference.md#CP_GO_NO_DATA) | Set to 1 to allow the vehicle to move in directions where there is no sensor coverage (default is 0/`False`).
 
 
-## Algorithm Description {#algorithm}
+<span id="algorithm"></span>
+## Algorithm Description
 
 The data from all sensors are fused into an internal representation of 36 sectors around the vehicle, each containing either the sensor data and information about when it was last observed, or an indication that no data for the sector was available.
 When the vehicle is commanded to move in a particular direction, all sectors in the hemisphere of that direction are checked to see if the movement will bring the vehicle closer to any obstacles.
@@ -63,7 +64,8 @@ If the sectors adjacent to the commanded sectors are 'better' by a significant m
 This helps to fine-tune user input to 'guide' the vehicle around obstacles rather than getting stuck against them.
 
 
-### Range Data Loss {#data_loss}
+<span id="data_loss"></span>
+### Range Data Loss
 
 If the autopilot does not receive range data from any sensor for longer than 0.5s, it will output a warning *No range data received, no movement allowed*.
 This will force the velocity setpoints in xy to zero.
@@ -76,7 +78,8 @@ The data of the faulty sensor will expire and the region covered by this sensor 
 > **Warning** Be careful when enabling [CP_GO_NO_DATA=1](#CP_GO_NO_DATA), which allows the vehicle to fly outside the area with sensor coverage.
   If you lose connection to one of multiple sensors, the area covered by the faulty sensor is also treated as uncovered and you will be able to move there without constraint.
 
-### CP_DELAY Delay Tuning {#delay_tuning}
+<span id="delay_tuning"></span>
+### CP_DELAY Delay Tuning
 
 There are two main sources of delay which should be accounted for: *sensor delay*, and vehicle *velocity setpoint tracking delay*.
 Both sources of delay are tuned using the [CP_DELAY](#CP_DELAY) parameter.
@@ -90,7 +93,8 @@ The tracking delay is typically between 0.1 and 0.5 seconds, depending on vehicl
 
 > **Tip** If vehicle speed oscillates as it approaches the obstacle (i.e. it slows down, speeds up, slows down) the delay is set too high.
 
-### CP_GUIDE_ANG Guidance Tuning {#angle_change_tuning}
+<span id="angle_change_tuning"></span>
+### CP_GUIDE_ANG Guidance Tuning
 
 Depending on the vehicle, type of environment and pilot skill different amounts of guidance may be desired.
 Setting the [CP_GUIDE_ANG](#CP_GUIDE_ANG) parameter to 0 will disable the guidance, resulting in the vehicle only moving exactly in the directions commanded.
@@ -104,7 +108,8 @@ From testing, 30 degrees is a good balance, although different vehicles may have
   If the vehicle feels 'stuck' with only a single distance sensor pointing forwards, this is probably because the guidance cannot safely adapt the direction due to lack of information.
 
 
-## PX4 Distance Sensor {#rangefinder}
+<span id="rangefinder"></span>
+## PX4 Distance Sensor
 
 At time of writing PX4 allows you to use the [Lanbao PSK-CM8JL65-CC5](../sensor/cm8jl65_ir_distance_sensor.md) IR distance sensor for collision prevention "out of the box", with minimal additional configuration:
 - First [attach and configure the sensor](../sensor/cm8jl65_ir_distance_sensor.md), and enable collision prevention (as described above, using [CP_DIST](#CP_DIST)).
@@ -121,7 +126,8 @@ Other sensors may be enabled, but this requires modification of driver code to s
   Please contribute back your changes!
 
 
-## Companion Setup {#companion}
+<span id="companion"></span>
+## Companion Setup
 
 If using a companion computer or external sensor, it needs to supply a stream of [OBSTACLE_DISTANCE](https://mavlink.io/en/messages/common.html#OBSTACLE_DISTANCE) messages, which should reflect when and where obstacle were detected.
 

--- a/en/computer_vision/obstacle_avoidance.md
+++ b/en/computer_vision/obstacle_avoidance.md
@@ -20,7 +20,8 @@ This topic explains how the feature is set up and enabled in both modes.
   > **Note** Obstacle avoidance can use the *local planner* planner emits messages at ~30Hz and can move at around 3 m/s) or global planner (emits messages at ~10Hz and mission speed with obstacle avoidance is around 1-1.5 m/s).
 
 
-## Offboard Mode Avoidance {#offboard_mode}
+<span id="offboard_mode"></span>
+## Offboard Mode Avoidance
 
 PX4 supports obstacle avoidance in [Offboard mode](../flight_modes/offboard.md).
 
@@ -33,7 +34,8 @@ The only required PX4-side setup is to put PX4 into *Offboard mode*.
 Companion-side hardware setup and hardware/software configuration is provided in the [PX4/avoidance](https://github.com/PX4/avoidance#obstacle-detection-and-avoidance) Github repo.
 
 
-## Mission Mode Avoidance {#mission_mode}
+<span id="mission_mode"></span>
+## Mission Mode Avoidance
 
 PX4 supports obstacle avoidance in [Mission mode](../flight_modes/mission.md), using avoidance software running on a separate companion computer.
 
@@ -70,7 +72,8 @@ Companion-side hardware setup and hardware/software configuration is provided in
 Obstacle avoidance in missions can use either the *local planner* or *global planner* (the local planner is recommended/better performing).
 
 
-## Obstacle Avoidance Interface {#interface}
+<span id="interface"></span>
+## Obstacle Avoidance Interface
 
 PX4 uses the [Path Planning Offboard Interface](../computer_vision/path_planning_interface.md) for integrating path planning services from a companion computer (including [Obstacle Avoidance in missions](../computer_vision/obstacle_avoidance.md#mission_mode), [Safe Landing](../computer_vision/safe_landing.md), and future services).
 

--- a/en/computer_vision/path_planning_interface.md
+++ b/en/computer_vision/path_planning_interface.md
@@ -35,7 +35,8 @@ The actual setup/configuration required depends on the planner being used.
   This means that offboard features that use different planners cannot be enabled on the same vehicle. a vehicle at the same time (e.g. a vehicle can support obstacle avoidance and collision prevent, but not also safe landing - or visa versa).
 
 
-## Trajectory Interface {#waypoint_interface}
+<span id="waypoint_interface"></span>
+## Trajectory Interface
 
 PX4 sends information about the *desired path* to the companion computer (when `COM_OBS_AVOID=1`, in _auto_ modes), and receives back a stream of setpoints for the *planned path* from the path planning software.
 
@@ -47,7 +48,8 @@ The difference is that the waypoint just specifies the next setpoint destination
 > **Warning** Route planning software should not mix these interfaces while executing a task (PX4 will use the last received message of either type).
 
 
-### PX4 Waypoint Interface {#px4_waypoint_interface}
+<span id="px4_waypoint_interface"></span>
+### PX4 Waypoint Interface
 
 PX4 sends the desired path in [TRAJECTORY_REPRESENTATION_WAYPOINTS](https://mavlink.io/en/messages/common.html#TRAJECTORY_REPRESENTATION_WAYPOINTS) messages at 5Hz.
 
@@ -86,7 +88,8 @@ Notes:
 - Point 1 is used by local and global planner.
 
 
-#### Handling of Companion Failure {#companion-failure-handling}
+<span id="companion-failure-handling"></span>
+#### Handling of Companion Failure
 
 PX4 safely handles the case where messages are not received from the offboard system:
 - If no planner is running and `COM_OBS_AVOID` is enabled at/from boot:
@@ -102,7 +105,8 @@ PX4 safely handles the case where messages are not received from the offboard sy
   - If the execution time of the last-supplied bezier trajectory expires during path planning (when using the [Bezier Trajectory Interface](#bezier_interface)), this is treated the same as not getting a new message within 0.5 seconds (i.e. vehicle switches to [Hold mode](../flight_modes/hold.md)).
 
 
-## Companion Waypoint Interface {#companion_waypoint_interface}
+<span id="companion_waypoint_interface"></span>
+## Companion Waypoint Interface
 
 The path planning software (running on the companion computer) *may* send the planned path to PX4 as a stream of [TRAJECTORY_REPRESENTATION_WAYPOINTS](https://mavlink.io/en/messages/common.html#TRAJECTORY_REPRESENTATION_WAYPOINTS) messages that have the setpoint in Point 0.
 
@@ -124,7 +128,8 @@ A planner that implements this interface must:
 - Mirror back setpoints it receives when it doesn't support planning for the current vehicle state (e.g. the local planner would mirror back messages sent during safe landing, because it does not support Land mode).
 
 
-## Companion Bezier Trajectory Interface {#bezier_interface}
+<span id="bezier_interface"></span>
+## Companion Bezier Trajectory Interface
 
 The path planning software (running on the companion computer) *may* send the planned path to PX4 as a stream of [TRAJECTORY_REPRESENTATION_BEZIER](https://mavlink.io/en/messages/common.html#TRAJECTORY_REPRESENTATION_BEZIER) messages.
 

--- a/en/computer_vision/safe_landing.md
+++ b/en/computer_vision/safe_landing.md
@@ -38,7 +38,8 @@ This covers the common setup for obstacle avoidance and collision prevention, an
 The configuration information includes, among other things, how to set up safe landing for different cameras, sizes of vehicles, and the height at which the decision to land or not is taken.
 
 
-## Safe Landing Interface {#interface}
+<span id="interface"></span>
+## Safe Landing Interface
 
 PX4 uses the [Path Planning Interface](../computer_vision/path_planning_interface.md) for integrating path planning services from a companion computer (including [Obstacle Avoidance in missions](../computer_vision/obstacle_avoidance.md#mission_mode), [Safe Landing](../computer_vision/safe_landing.md), and future services).
 

--- a/en/computer_vision/visual_inertial_odometry.md
+++ b/en/computer_vision/visual_inertial_odometry.md
@@ -18,7 +18,8 @@ https://youtu.be/gWtrka2mK7U
   PX4 itself does not care about the source of messages, provided they are provided via the appropriate [MAVLink Interface](https://dev.px4.io/master/en/ros/external_position_estimation.html#px4-mavlink-integration).
 
 
-## Supported Setup {#supported_setup}
+<span id="supported_setup"></span>
+## Supported Setup
 
 The supported setup uses the [T265 Intel Realsense Tracking Camera](../peripherals/camera_t265_vio.md) and ROS (running on a companion computer) to supply odometry information to PX4.
 The Auterion [VIO bridge ROS node](https://github.com/Auterion/VIO_bridge) provides a bridge between this (particular) camera and ROS.
@@ -78,7 +79,8 @@ To setup the Bridge, ROS and PX4:
 
 
 
-### PX4 Tuning {#ekf2_tuning}
+<span id="ekf2_tuning"></span>
+### PX4 Tuning
 
 The following parameters must be set to use external position information with EKF2.
 
@@ -95,7 +97,8 @@ For more detailed/additional information, see: [ECL/EKF Overview & Tuning > Exte
 
 
 
-#### Tuning EKF2_EV_DELAY {#tuning-EKF2_EV_DELAY}
+<span id="tuning-EKF2_EV_DELAY"></span>
+#### Tuning EKF2_EV_DELAY
 
 [EKF2_EV_DELAY](../advanced_config/parameter_reference.md#EKF2_EV_DELAY) is the *Vision Position Estimator delay relative to IMU measurements*.
 In other words, it is the difference between the vision system timestamp and the "actual" capture time that would have been recorded by the IMU clock (the "base clock" for EKF2).
@@ -113,7 +116,8 @@ A rough estimate of the delay can be obtained from logs by checking the offset b
 The value can further be tuned by varying the parameter to find the value that yields the lowest EKF innovations during dynamic maneuvers.
 
 
-## Check/Verify VIO Estimate {#verify_estimate}
+<span id="verify_estimate"></span>
+## Check/Verify VIO Estimate
 
 Perform the following checks to verify that VIO is working properly *before* your first flight:
 

--- a/en/config/battery.md
+++ b/en/config/battery.md
@@ -25,7 +25,8 @@ The approach you use will depend on whether the vehicle's power module can measu
   All battery calibration parameters [are listed here](../advanced_config/parameter_reference.md#battery-calibration).
 
 
-## Basic Battery Settings (default) {#basic_settings}
+<span id="basic_settings"></span>
+## Basic Battery Settings (default)
 
 The basic battery settings configure PX4 to use the default method for capacity estimate. 
 This method compares the measured raw battery voltage to the range between cell voltages for "empty" and "full" cells (scaled by the number of cells). 
@@ -102,7 +103,8 @@ The easiest way to calibrate the divider is by using *QGroundControl* and follow
 
 > **Note** This setting corresponds to parameters: [BAT1_V_DIV](../advanced_config/parameter_reference.md#BAT1_V_DIV) and [BAT2_V_DIV](../advanced_config/parameter_reference.md#BAT2_V_DIV).
 
-### Amps per volt {#current_divider}
+<span id="current_divider"></span>
+### Amps per volt
 
 > **Tip** This setting is not needed if you are using the basic configuration (without load compensation etc.)
 
@@ -113,7 +115,8 @@ The easiest way to calibrate the dividers is by using *QGroundControl* and follo
 > **Note** This setting corresponds to parameter(s): [BAT1_A_PER_V](../advanced_config/parameter_reference.md#BAT1_A_PER_V) and [BAT2_A_PER_V](../advanced_config/parameter_reference.md#BAT2_A_PER_V).
 
 
-## Voltage-based Estimation with Load Compensation {#load_compensation}
+<span id="load_compensation"></span>
+## Voltage-based Estimation with Load Compensation
 
 > **Note** With well configured load compensation the voltage used for battery capacity estimation is much more stable, varying far less when flying up and down.
 
@@ -125,7 +128,8 @@ PX4 supports two load compensation methods, which are enabled by [setting](../ad
 * [BAT1_R_INTERNAL](../advanced_config/parameter_reference.md#BAT1_R_INTERNAL) - [Current-based Load Compensation](#current_based_load_compensation) (recommended).
 * [BAT1_V_LOAD_DROP](../advanced_config/parameter_reference.md#BAT1_V_LOAD_DROP) - [Thrust-based Load Compensation](#thrust_based_load_compensation).
 
-### Current-based Load Compensation (recommended) {#current_based_load_compensation}
+<span id="current_based_load_compensation"></span>
+### Current-based Load Compensation (recommended)
 
 This load compensation method relies on current measurement to determine load.
 It is far more accurate than [Thrust-based Load Compensation](#thrust_based_load_compensation) but requires that you have a current sensor.
@@ -137,7 +141,8 @@ To enable this feature:
      A typical value is 5mΩ per cell but this can vary with discharge current rating, age and health of the cells.
 1. You should also calibrate the [Amps per volt divider](#current_divider) in the basic settings screen.
 
-### Thrust-based Load Compensation {#thrust_based_load_compensation}
+<span id="thrust_based_load_compensation"></span>
+### Thrust-based Load Compensation
 
 This load compensation method estimates the load based on the total thrust that gets commanded to the motors. 
 
@@ -148,7 +153,8 @@ To enable this feature:
 1. Set the parameter [BAT1_V_LOAD_DROP](../advanced_config/parameter_reference.md#BAT1_V_LOAD_DROP) to how much voltage drop a cell shows under the load of full throttle.
 
 
-## Voltage-based Estimation Fused with Current Integration {#current_integration}
+<span id="current_integration"></span>
+## Voltage-based Estimation Fused with Current Integration
 
 > **Note** This is the most accurate way to measure relative battery consumption. If set up correctly with a healthy and fresh charged battery on every boot, then the estimation quality will be comparable to that from a smart battery (and theoretically allow for accurate remaining flight time estimation).
 

--- a/en/config/firmware.md
+++ b/en/config/firmware.md
@@ -39,7 +39,8 @@ To install PX4:
 Next you will need to specify the [vehicle airframe](../config/airframe.md) (and then sensors, radio, etc.)
 
 
-## Installing PX4 Master, Beta or Custom Firmware {#custom}
+<span id="custom"></span>
+## Installing PX4 Master, Beta or Custom Firmware
 
 To install a different version of PX4:
 1. Connect the vehicle as above, and select **PX4 Flight Stack vX.x.x Stable Release**
@@ -55,7 +56,8 @@ To install a different version of PX4:
 Firmware update then continues as before.
 
 
-## FMUv2 Bootloader Update {#bootloader}
+<span id="bootloader"></span>
+## FMUv2 Bootloader Update
 
 If *QGroundControl* installs the FMUv2 target (see console during installation), and you have a newer board, you may need to update the bootloader in order to access all the memory on your flight controller.
 

--- a/en/config/flight_mode.md
+++ b/en/config/flight_mode.md
@@ -35,7 +35,8 @@ It is also common to map switches to:
 
 > **Tip** The recommended approach is use *Single Channel Mode Selection* because it easy to understand and configure. 
 
-## Single-Channel Flight Mode Selection {#single_channel}
+<span id="single_channel"></span>
+## Single-Channel Flight Mode Selection
 
 The single-channel selection mode allows you to specify a "mode" channel and select up to 6 flight modes that will be activated based on the PWM value of the channel. You can also separately specify channels for mapping a kill switch, return to launch mode, and offboard mode.
 
@@ -63,7 +64,8 @@ To configure single-channel flight mode selection:
 
 All values are automatically saved as they are changed.
 
-### Single-Channel Setup Video Example (including Transmitter Setup) {#taranis_setup}
+<span id="taranis_setup"></span>
+### Single-Channel Setup Video Example (including Transmitter Setup)
 
 It is common to use the positions of a 2- and a 3-position switch on the transmitter to represent the 6 flight modes, and encode each combination of switches as a particular PWM value for the mode that will be sent on a single channel. 
 
@@ -99,7 +101,8 @@ For example, below we map channel 6 to the [RC_MAP_ARM_SW](../advanced_config/pa
 ![QGC - Map ARM switch to channel](../../assets/qgc/setup/flight_modes/single_channel_mode_selection_4.png)
 
 
-## Multi-Channel Flight Mode Selection {#multi_channel}
+<span id="multi_channel"></span>
+## Multi-Channel Flight Mode Selection
 
 > **Tip** We recommend you use [Single Channel Flight Mode](#single_channel) selection because the Multi Channel selection user interface can be confusing. If you do choose to use this method, then the best approach is to start assigning channels and take note of information displayed by *QGroundControl* following your selection. 
 

--- a/en/config/radio.md
+++ b/en/config/radio.md
@@ -12,7 +12,8 @@ Before you can calibrate the radio system the receiver and transmitter must be c
 > **Note** If you are using a *FrSky* receiver, you can bind it with its transmitter, by following instructions [here](https://www.youtube.com/watch?v=1IYg5mQdLVI).
 
 
-## RC Loss Detection {#rc_loss_detection}
+<span id="rc_loss_detection"></span>
+## RC Loss Detection
 
 PX4 needs to be able to detect when the signal from the RC controller has been lost in order to be able to take [appropriate safety measures](../config/safety.md#rc_loss_failsafe).
 

--- a/en/config/safety.md
+++ b/en/config/safety.md
@@ -7,7 +7,8 @@ PX4 has a number of safety features to protect and recover your vehicle if somet
   Others must be configured via [parameters](#failsafe_other).
 * [Safety switches](#safety_switch) on the remote control can be used to immediately stop motors or return the vehicle in the event of a problem.
 
-## Failsafe Actions {#failsafe_actions}
+<span id="failsafe_actions"></span>
+## Failsafe Actions
 
 Each failsafe defines its own set of actions.
 Some of the more common failsafe actions are:
@@ -31,7 +32,8 @@ Action | Description
   This might result in the vehicle being changed to a manual mode so the user can directly manage recovery.
 
 
-## QGroundControl Safety Setup {#qgc_safety_setup}
+<span id="qgc_safety_setup"></span>
+## QGroundControl Safety Setup
 
 The *QGroundControl* Safety Setup page is accessed by clicking the *QGroundControl* **Gear** icon (Vehicle Setup - top toolbar) and then **Safety** in the sidebar).
 This includes the most important failsafe settings (battery, RC loss etc.) and the settings for the return actions *Return* and *Land*.
@@ -60,7 +62,8 @@ Battery Warn Level | [BAT_LOW_THR](../advanced_config/parameter_reference.md#BAT
 Battery Emergency Level | [BAT_EMERGEN_THR](../advanced_config/parameter_reference.md#BAT_EMERGEN_THR) | Percentage capacity for triggering Land (immediately) action.
 
 
-### RC Loss Failsafe {#rc_loss_failsafe}
+<span id="rc_loss_failsafe"></span>
+### RC Loss Failsafe
 
 The RC Loss failsafe is triggered if the RC transmitter link is lost *in manual modes* (RC loss does not trigger the failsafe in automatic modes - e.g. during missions).
 
@@ -119,7 +122,8 @@ Geofence source | [GF_SOURCE](../advanced_config/parameter_reference.md#GF_SOURC
 <span id="CBRK_FLIGHTTERM"></span>Circuit breaker for flight termination | [CBRK_FLIGHTTERM](../advanced_config/parameter_reference.md#CBRK_FLIGHTTERM) | Enables/Disables flight termination action (disabled by default).
 
 
-### Return Mode Settings {#return_settings}
+<span id="return_settings"></span>
+### Return Mode Settings
 
 *Return* is a common [failsafe action](#failsafe_actions) that engages [Return mode](../flight_modes/return.md) to return the vehicle to the home position.
 This section shows how to set the land/loiter behaviour after returning.
@@ -156,7 +160,8 @@ Disarm After | [COM_DISARM_LAND](../advanced_config/parameter_reference.md#COM_D
 Landing Descent Rate | [MPC_LAND_SPEED](../advanced_config/parameter_reference.md#MPC_LAND_SPEED) | Rate of descent (MC only).
 
 
-## Other Failsafe Settings {#failsafe_other}
+<span id="failsafe_other"></span>
+## Other Failsafe Settings
 
 This section contains information about failsafe settings that cannot be configured through the *QGroundControl* [Safety Setup](#qgc_safety_setup) page.
 
@@ -243,7 +248,8 @@ Parameter | Description
 [VT_FW_ALT_ERR](../advanced_config/parameter_reference.md#VT_FW_ALT_ERR) | Maximum negative altitude error for fixed wing flight. If the altitude drops more than this value below the altitude setpoint the vehicle will transition back to MC mode and enter failsafe RTL.
 
 
-## Failure Detector {#failure_detector}
+<span id="failure_detector"></span>
+## Failure Detector
 
 The failure detector allows a vehicle to take protective action(s) if it unexpectedly flips, or if it is notified by an external failure detection system.
 
@@ -258,7 +264,8 @@ The failure detector is active in all vehicle types and modes, except for those 
 
 
 
-### Attitude Trigger {#attitude_trigger}
+<span id="attitude_trigger"></span>
+### Attitude Trigger
 
 The failure detector can be configured to trigger if the vehicle attitude exceeds predefined pitch and roll values for longer than a specified time.
 
@@ -272,7 +279,8 @@ Parameter | Description
 <span id="FD_FAIL_P_TTRI"></span>[FD_FAIL_P_TTRI](../advanced_config/parameter_reference.md#FD_FAIL_P_TTRI) | Time to exceed [FD_FAIL_P](#FD_FAIL_P) for failure detection (default 0.3s).
 <span id="FD_FAIL_R_TTRI"></span>[FD_FAIL_R_TTRI](../advanced_config/parameter_reference.md#FD_FAIL_R_TTRI) | Time to exceed [FD_FAIL_R](#FD_FAIL_R) for failure detection (default 0.3s).
 
-### External Automatic Trigger System (ATS) {#external_ats}
+<span id="external_ats"></span>
+### External Automatic Trigger System (ATS)
 
 The [failure detector](#failure_detector), if [enabled](#CBRK_FLIGHTTERM), can also be triggered by an external ATS system.
 The external trigger system must be connected to flight controller port AUX5 (or MAIN5 on boards that do not have AUX ports), and is configured using the parameters below.
@@ -286,19 +294,22 @@ Parameter | Description
 <span id="FD_EXT_ATS_TRIG"></span>[FD_EXT_ATS_TRIG](../advanced_config/parameter_reference.md#FD_EXT_ATS_TRIG) | The PWM threshold from external automatic trigger system for engaging failsafe. Default: 1900 ms.
 
 
-## Emergency Switches {#safety_switch}
+<span id="safety_switch"></span>
+## Emergency Switches
 
 Remote control switches can be configured (as part of *QGroundControl* [Flight Mode Setup](../config/flight_mode.md)) to allow you to take rapid corrective action in the event of a problem or emergency; for example, to stop all motors, or activate [Return mode](#return_switch).
 
 This section lists the available emergency switches.
 
-### Kill Switch {#kill_switch}
+<span id="kill_switch"></span>
+### Kill Switch
 
 A kill switch immediately stops all motor outputs (and if flying, the vehicle will start to fall)!
 The motors will restart if the switch is reverted within 5 seconds.
 After 5 seconds the vehicle will automatically disarm; you will need to arm it again in order to start the motors.
 
-### Arm/Disarm Switch {#arming_switch}
+<span id="arming_switch"></span>
+### Arm/Disarm Switch
 
 The arm/disarm switch is a *direct replacement* for the default stick-based arming/disarming mechanism (and serves the same purpose: making sure there is an intentional step involved before the motors start/stop).
 It might be used in preference to the default mechanism because:
@@ -324,14 +335,16 @@ This includes *Position mode* and autonomous modes (e.g. *Mission*, *Land* etc.)
 -->
 
 
-### Return Switch {#return_switch}
+<span id="return_switch"></span>
+### Return Switch
 
 A return switch can be used to immediately engage [Return mode](../flight_modes/return.md).
 
 
 ## Other Safety Settings
 
-### Auto-disarming Timeouts {#auto-disarming-timeouts}
+<span id="auto-disarming-timeouts"></span>
+### Auto-disarming Timeouts
 
 You can set timeouts to automatically disarm a vehicle if it is too slow to takeoff, and/or after landing (disarming the vehicle removes power to the motors, so the propellers won't spin).
 

--- a/en/config_mc/mc_slew_rate_type_trajectory.md
+++ b/en/config_mc/mc_slew_rate_type_trajectory.md
@@ -31,7 +31,8 @@ This parameter is used for position-control in the horizontal direction, where t
 The limit for the rate of change of the velocity setpoint is defined by [MPC_ACC_HOR_MAX](../advanced_config/parameter_reference.md#MPC_ACC_HOR_MAX).
 This parameter should be set larger than any of the other acceleration related parameters in the horizontal direction.
 
-#### MPC_ACC_HOR and MPC_DEC_HOR_SLOW {#mpc_acc_hor-and-mpc_dec_hor_slow}
+<span id="mpc_acc_hor-and-mpc_dec_hor_slow"></span>
+#### MPC_ACC_HOR and MPC_DEC_HOR_SLOW
 
 In velocity-control the rate limit for the velocity setpoint is extracted from a linear map from stick input to acceleration limit with maximum [MPC_ACC_HOR](../advanced_config/parameter_reference.md#MPC_ACC_HOR) and minimum [MPC_DEC_HOR_SLOW](../advanced_config/parameter_reference.md#MPC_DEC_HOR_SLOW).
 For example, if the stick input is at `MPC_HOLD_DZ`, the limiting acceleration is `MPC_DEC_HOR_SLOW`.

--- a/en/config_mc/mc_trajectory_tuning.md
+++ b/en/config_mc/mc_trajectory_tuning.md
@@ -27,7 +27,8 @@ Vehicle flight characteristics are better if the corresponding desired setpoint 
   Poorly tuned *setpoint values* cannot result in instability, but may result in either very jerky or very unresponsive reactions to setpoint changes.
 
 
-## Flight Modes Trajectory Support {#modes}
+<span id="modes"></span>
+## Flight Modes Trajectory Support
 
 [Mission mode](../flight_modes/mission.md) used the [Jerk-limited](../config_mc/mc_jerk_limited_type_trajectory.md) trajectory all the time.
 
@@ -39,7 +40,8 @@ It uses the [Jerk-limited](../config_mc/mc_jerk_limited_type_trajectory.md) traj
 No other modes support trajectory tuning.
 
 
-## Trajectory Implementations {#trajectory_implementation}
+<span id="trajectory_implementation"></span>
+## Trajectory Implementations
 
 The following list provides an *overview* of the different trajectory implementations:
 

--- a/en/config_mc/pid_tuning_guide_multicopter.md
+++ b/en/config_mc/pid_tuning_guide_multicopter.md
@@ -82,14 +82,16 @@ The two forms are described below.
   - [PID controller > Standard versus parallel (ideal) PID form](https://en.wikipedia.org/wiki/PID_controller#Standard_versus_parallel_(ideal)_PID_form) (Wikipedia)
 
 
-##### Parallel Form {#parallel_form}
+<span id="parallel_form"></span>
+##### Parallel Form
 
 The *parallel form* is the simplest form, and is (hence) commonly used in textbooks.
 In this case the output of the controller is simply the sum of the proportional, integral and derivative actions.
 
 ![PID_Parallel](../../assets/mc_pid_tuning/PID_algorithm_Parallel.png)
 
-##### Standard Form {#standard_form}
+<span id="standard_form"></span>
+##### Standard Form
 
 This form is mathematically equivalent to the parallel form, but the main advantage is that (even if it seems counter intuitive) it decouples the proportional gain tuning from the integral and derivative gains.
 This means that a new platform can easily be tuned by taking the gains of a drone with similar size/inertia and simply adjust the K gain to have it flying properly.
@@ -200,7 +202,8 @@ The following parameters can also be adjusted. These determine the maximum rotat
 - Maximum yaw rate ([MC_YAWRATE_MAX](../advanced_config/parameter_reference.md#MC_YAWRATE_MAX))
 
 
-### Thrust Curve {#thrust_curve}
+<span id="thrust_curve"></span>
+### Thrust Curve
 
 The tuning above optimises performance around the hover throttle.
 But it can be that you start to see oscillations when going towards full throttle.
@@ -242,7 +245,8 @@ turn off all [higher-level position controller tuning gains](../config_mc/mc_tra
  -->
 
 
-### Airmode & Mixer Saturation {#airmode}
+<span id="airmode"></span>
+### Airmode & Mixer Saturation
 
 The rate controller outputs torque commands for all three axis (roll, pitch and yaw) and a scalar thrust value, which need to be converted into individual motor thrust commands.
 This step is called mixing.

--- a/en/config_mc/racer_setup.md
+++ b/en/config_mc/racer_setup.md
@@ -108,7 +108,8 @@ This is important for the [filter](#filters) tuning.
 There will be a second PID tuning round later.
 
 
-### Control Latency {#control_latency}
+<span id="control_latency"></span>
+### Control Latency
 
 The *control latency* is the delay from a physical disturbance of the vehicle until the motors react to the change.
 
@@ -123,7 +124,8 @@ These are the factors that affect the latency:
   To avoid the IO delay, disable [SYS_USE_IO](../advanced_config/parameter_reference.md#SYS_USE_IO) and attach the motors to the AUX pins instead.
 - PWM output signal: enable One-Shot to reduce latency ([PWM_RATE](../advanced_config/parameter_reference.md#PWM_RATE)=0) 
 
-### Filters {#filters}
+<span id="filters"></span>
+### Filters
 
 <!-- TODO: this probably should be documented somewhere else -->
 As mentioned in the previous section, filters affect the control latency. 

--- a/en/config_vtol/vtol_quad_configuration.md
+++ b/en/config_vtol/vtol_quad_configuration.md
@@ -37,7 +37,8 @@ While it might seem that you are dealing with a vehicle that can fly in two mode
 
 Getting your transition tuning right is important for obtaining a safe entry into fixed wing mode, for example, if your airspeed is too slow when it transitions it might stall.
 
-#### Transition Throttle {#transition_throttle}
+<span id="transition_throttle"></span>
+#### Transition Throttle
 
 Parameter: [VT_F_TRANS_THR](../advanced_config/parameter_reference.md#VT_F_TRANS_THR)
 
@@ -92,7 +93,8 @@ As soon as a transition to fixed wing occurs it will be stabilised.
 Note that if you have not yet tuned your fixed wing mode you should leave this off until you are sure it behaves well in this mode.
 
 
-### Transitioning Tips {#transitioning_tips}
+<span id="transitioning_tips"></span>
+### Transitioning Tips
 
 As already mentioned make sure you have a well tuned multirotor mode.
 If during a transition something goes wrong you will switch back to this mode and it should be quite smooth.
@@ -139,7 +141,8 @@ Because the wing will still be flying you’ll find you have plenty of time to a
 For advanced tuning of the back-transition please refer to the [Back-transition Tuning Guide](vtol_back_transition_tuning.md)
 
 
-#### Aborting a Transition {#aborting_a_transition}
+<span id="aborting_a_transition"></span>
+#### Aborting a Transition
 
 It’s important to know what to expect when you revert a transition command *during* a transition.
 

--- a/en/config_vtol/vtol_weathervane.md
+++ b/en/config_vtol/vtol_weathervane.md
@@ -19,7 +19,8 @@ The target yaw rate is the sum of weather vane yaw rate and user commanded yaw r
 In [Mission mode](../flight_modes/mission.md) the weather vane feature will always be active when the parameter is enabled.
 Any yaw angle commanded in a mission will be ignored.
 
-## Configuration {#configuration}
+<span id="configuration"></span>
+## Configuration
 
 This functionality is configured using the [WV_* parameters](../advanced_config/parameter_reference.md#WV_EN).
 

--- a/en/flight_controller/beaglebone_blue.md
+++ b/en/flight_controller/beaglebone_blue.md
@@ -134,7 +134,8 @@ sudo ./bin/px4 -s px4.config
 > **Note** Currently *librobotcontrol* requires root access.
 
 
-## Native Builds (optional) {#native_builds}
+<span id="native_builds"></span>
+## Native Builds (optional)
 
 You can also natively build PX4 builds directly on the BeagleBone Blue.
 

--- a/en/flight_controller/cuav_v5.md
+++ b/en/flight_controller/cuav_v5.md
@@ -48,7 +48,8 @@ It is intended primarily for academic and commercial developers.
 
 Order from [CUAV](https://cuav.taobao.com/index.htm?spm=2013.1.w5002-16371268426.2.411f26d9E18eAz).
 
-## Connection {#connection}
+<span id="connection"></span>
+## Connection
 
 ![CUAV v5](../../assets/flight_controller/cuav_v5/pixhack_v5_connector.jpg)
 

--- a/en/flight_controller/cuav_v5_nano.md
+++ b/en/flight_controller/cuav_v5_nano.md
@@ -62,12 +62,14 @@ Main FMU Processor: STM32F765◦32 Bit Arm® Cortex®-M7, 216MHz, 2MB memory, 51
 > **Note** Autopilot may be purchased with included Neo GPS module
 
 
-## Connections (Wiring) {#connection}
+<span id="connection"></span>
+## Connections (Wiring)
 
 [V5 nano Wiring Quickstart](../assembly/quick_start_cuav_v5_nano.md)
 
 
-## Pinouts {#pinouts}
+<span id="pinouts"></span>
+## Pinouts
 
 Download **V5 nano** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).
 
@@ -82,7 +84,8 @@ To [build PX4](https://dev.px4.io/master/en/setup/building_px4.html) for this ta
 make px4_fmu-v5_default
 ```
 
-## Debug Port {#debug_port}
+<span id="debug_port"></span>
+## Debug Port
 
 The [PX4 System Console](https://dev.px4.io/master/en/debug/system_console.html) and [SWD interface](http://dev.px4.io/master/en/debug/swd_debug.html) operate on the **FMU Debug** port (`DSU7`).
 The board does not have an I/O debug interface.
@@ -142,7 +145,8 @@ UART8 | /dev/ttyS6 | Not connected (no PX4IO)
 The *V5 nano* has no over current protection.
 
 
-## Peripherals {#Optional-hardware}
+<span id="Optional-hardware"></span>
+## Peripherals
 
 * [Digital Airspeed Sensor](https://item.taobao.com/item.htm?spm=a1z10.3-c-s.w4002-16371268452.37.6d9f48afsFgGZI&id=9512463037)
 * [Telemetry Radio Modules](https://cuav.taobao.com/category-158480951.htm?spm=2013.1.w5002-16371268426.4.410b7a821qYbBq&search=y&catName=%CA%FD%B4%AB%B5%E7%CC%A8)
@@ -157,13 +161,15 @@ The complete set of supported configurations can be seen in the [Airframes Refer
 
 CUAV adopts some differentiated designs and is incompatible with some hardware, which will be described below.
 
-#### Neo v2.0 GPS not compatible with other devices {#compatibility_gps}
+<span id="compatibility_gps"></span>
+#### Neo v2.0 GPS not compatible with other devices
 
 The *Neo v2.0 GPS* that is recommended for use with *CUAV V5+* and *CUAV V5 nano* is not fully compatible with other Pixhawk flight controllers (specifically, the buzzer part is not compatible and there may be issues with the safety switch).
 
 The UAVCAN [NEO V2 PRO GNSS receiver](http://doc.cuav.net/gps/neo-v2-pro/en/#enable) can also be used, and is compatible with other flight controllers.
 
-#### Using JTAG for hardware debugging {#compatibility_jtag}
+<span id="compatibility_jtag"></span>
+#### Using JTAG for hardware debugging
 
 `DSU7` FMU Debug Pin 1 is 5 volts - not the 3.3 volts of the CPU.
 
@@ -171,7 +177,8 @@ Some JTAG probes use this voltage to set the IO levels when communicating to the
 
 For direct connection to *Segger Jlink* we recommended you use the 3.3 Volts of DSM/SBUS/RSSI pin 4 as Pin 1 on the debug connector (`Vtref`).
 
-#### PM2 cannot power the flight controller {#compatibility_pm2}
+<span id="compatibility_pm2"></span>
+#### PM2 cannot power the flight controller
 
 `PM2` can only measure battery voltage and current, but **not** power the flight controller.
 
@@ -183,7 +190,8 @@ The issues below refer to the *batch number* in which they first appear.
 The batch number is the four-digit production date behind V01 and is displayed on a sticker on the side of the flight controller.
 For example, the serial number Batch V011904((V01 is the number of V5, 1904 is the production date, that is, the batch number).
 
-#### SBUS / DSM / RSSI interface Pin1 unfused {#pin1_unfused}
+<span id="pin1_unfused"></span>
+#### SBUS / DSM / RSSI interface Pin1 unfused
 
 > **Warning** This is a safety issue. 
 

--- a/en/flight_controller/cuav_v5_nano.md
+++ b/en/flight_controller/cuav_v5_nano.md
@@ -68,7 +68,6 @@ Main FMU Processor: STM32F765◦32 Bit Arm® Cortex®-M7, 216MHz, 2MB memory, 51
 [V5 nano Wiring Quickstart](../assembly/quick_start_cuav_v5_nano.md)
 
 
-<span id="pinouts"></span>
 ## Pinouts
 
 Download **V5 nano** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).

--- a/en/flight_controller/cuav_v5_plus.md
+++ b/en/flight_controller/cuav_v5_plus.md
@@ -66,7 +66,6 @@ Some of its main features include:
 
 [CUAV V5+ Wiring Quickstart](../assembly/quick_start_cuav_v5_plus.md)
 
-<span id="pinouts"></span>
 ## Pinouts
 
 Download **V5+** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).

--- a/en/flight_controller/cuav_v5_plus.md
+++ b/en/flight_controller/cuav_v5_plus.md
@@ -61,11 +61,13 @@ Some of its main features include:
 
 > **Note** Autopilot may be purchased with included Neo GPS module
 
-## Connections (Wiring) {#connection}
+<span id="connection"></span>
+## Connections (Wiring)
 
 [CUAV V5+ Wiring Quickstart](../assembly/quick_start_cuav_v5_plus.md)
 
-## Pinouts {#pinouts}
+<span id="pinouts"></span>
+## Pinouts
 
 Download **V5+** pinouts from [here](http://manual.cuav.net/V5-Plus.pdf).
 
@@ -149,7 +151,8 @@ UART7 | /dev/ttyS5 | Debug Console
 UART8 | /dev/ttyS6 | PX4IO
 
 
-## Peripherals {#optional-hardware}
+<span id="optional-hardware"></span>
+## Peripherals
 
 * [Digital Airspeed Sensor](https://item.taobao.com/item.htm?spm=a1z10.3-c-s.w4002-16371268452.37.6d9f48afsFgGZI&id=9512463037)
 * [Telemetry Radio Modules](https://cuav.taobao.com/category-158480951.htm?spm=2013.1.w5002-16371268426.4.410b7a821qYbBq&search=y&catName=%CA%FD%B4%AB%B5%E7%CC%A8)
@@ -173,13 +176,15 @@ Similarly, a digital PM plugged into a analog connector will not work, and may a
 
 CUAV adopts some differentiated designs and is incompatible with some hardware, which will be described below.
 
-#### GPS not compatible with other devices {#compatibility_gps}
+<span id="compatibility_gps"></span>
+#### GPS not compatible with other devices
 
 The *Neo v2.0 GPS* recommended for use with *CUAV V5+* and *CUAV V5 nano* is not fully compatible with other Pixhawk flight controllers (specifically, the buzzer part is not compatible and there may be issues with the safety switch).
 
 The UAVCAN [NEO V2 PRO GNSS receiver](http://doc.cuav.net/gps/neo-v2-pro/en/#enable) can also be used, and is compatible with other flight controllers.
 
-#### Using JTAG for hardware debugging {#compatibility_jtag}
+<span id="compatibility_jtag"></span>
+#### Using JTAG for hardware debugging
 
 `DSU7` FMU Debug Pin 1 is 5 volts - not the 3.3 volts of the CPU.
 
@@ -193,7 +198,8 @@ The issues below refer to the *batch number* in which they first appear.
 The batch number is the four-digit production date behind V01 and is displayed on a sticker on the side of the flight controller.
 For example, the serial number Batch V011904((V01 is the number of V5, 1904 is the production date, that is, the batch number).
 
-#### SBUS / DSM / RSSI interface Pin1 unfused {#pin1_unfused}
+<span id="pin1_unfused"></span>
+#### SBUS / DSM / RSSI interface Pin1 unfused
 
 > **Warning** This is a safety issue.
 

--- a/en/flight_controller/cubepilot_cube_orange.md
+++ b/en/flight_controller/cubepilot_cube_orange.md
@@ -28,7 +28,8 @@ Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as
 * microSD card for high-rate logging over extended periods of time
 
 
-## Where to Buy {#stores}
+<span id="stores"></span>
+## Where to Buy
 
 * [The Cube](http://www.proficnc.com/61-system-kits) (ProfiCNC)
 

--- a/en/flight_controller/cubepilot_cube_yellow.md
+++ b/en/flight_controller/cubepilot_cube_yellow.md
@@ -28,7 +28,8 @@ Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as
 * microSD card for high-rate logging over extended periods of time
 
 
-## Where to Buy {#stores}
+<span id="stores"></span>
+## Where to Buy
 
 * [The Cube](http://www.proficnc.com/61-system-kits) (ProfiCNC)
 

--- a/en/flight_controller/durandal.md
+++ b/en/flight_controller/durandal.md
@@ -75,12 +75,14 @@ A summary of the key features, [assembly](../assembly/quick_start_durandal.md), 
 
 For more information see: [Durandal Technical Data Sheet](http://www.holybro.com/manual/Durandal_technical_data_sheet.pdf).
 
-## Purchase {#purchase}
+<span id="purchase"></span>
+## Purchase
 
 Order from [Holybro](https://shop.holybro.com/durandalbeta_p1189.html).
 
 
-## Connections {#connections}
+<span id="connections"></span>
+## Connections
 
 The locations of ports/connections are shown here (and below in the [pinouts section](#pinouts)).
 
@@ -159,7 +161,8 @@ UART7 | /dev/ttyS5 | Debug Console
 UART8 | /dev/ttyS6 | PX4IO
 
 
-## Debug Port {#debug_port}
+<span id="debug_port"></span>
+## Debug Port
 
 The [PX4 System Console](https://dev.px4.io/master/en/debug/system_console.html) and [SWD interface](http://dev.px4.io/master/en/debug/swd_debug.html) run on the *Debug Port*.
 
@@ -233,7 +236,8 @@ Pin | Signal | Volt
 4 (black) | GND | GND
 
 
-#### GPS port {#gps}
+<span id="gps"></span>
+#### GPS port
 
 Pin | Signal | Volt
 --- | --- | ---
@@ -248,7 +252,8 @@ Pin | Signal | Volt
 9 (black) | BUZZER | +5V
 10 (black) | GND | GND
 
-#### TELEM4 I2CB ports {#telem4_i2cb}
+<span id="telem4_i2cb"></span>
+#### TELEM4 I2CB ports
 
 Pin | Signal | Volt
 --- | --- | ---
@@ -259,7 +264,8 @@ Pin | Signal | Volt
 5 (black) | SDA2 | +3.3V
 6 (black) | GND | GND
 
-#### TELEM3, TELEM2, TELEM1 port {#telem1_2_3}
+<span id="telem1_2_3"></span>
+#### TELEM3, TELEM2, TELEM1 port
 
 Pin | Signal | Volt
 --- | --- | ---
@@ -270,7 +276,8 @@ Pin | Signal | Volt
 5 (black) | RTS (out) | +3.3V
 6 (black) | GND | GND
 
-#### POWER port {#power}
+<span id="power"></span>
+#### POWER port
 
 Pin | Signal | Volt
 --- | --- | ---
@@ -355,7 +362,8 @@ Pin | Signal | Volt
 
 ![Durandal - Left-side Pinouts (Schematic)](../../assets/flight_controller/durandal/durandal_pinouts_left.jpg)
 
-#### DEBUG port {#debug_port}
+<span id="debug_port"></span>
+#### DEBUG port
 
 Pin | Signal | Volt
 --- | --- | ---

--- a/en/flight_controller/kakutef7.md
+++ b/en/flight_controller/kakutef7.md
@@ -62,7 +62,8 @@ This is the silkscreen for the *Kakute F7*, showing the top of the board:
 | Boot | Bootloader button | |
 
 
-## PX4 Bootloader Update {#bootloader}
+<span id="bootloader"></span>
+## PX4 Bootloader Update
 
 The board comes pre-installed with [Betaflight](https://github.com/betaflight/betaflight/wiki). 
 Before PX4 firmware can be installed, the *PX4 bootloader* must be flashed.

--- a/en/flight_controller/omnibus_f4_sd.md
+++ b/en/flight_controller/omnibus_f4_sd.md
@@ -147,7 +147,8 @@ USART6 | /dev/ttyS2 | GPS
 The Omnibus supports telemetry to the RC Transmitter using [FrSky Telemetry](../peripherals/frsky_telemetry.md) or [CRSF Crossfire Telemetry](#crsf_telemetry).
 
 
-### CRSF Crossfire Telemetry {#crsf_telemetry}
+<span id="crsf_telemetry"></span>
+### CRSF Crossfire Telemetry
 
 TBS CRSF Crossfire telemetry is used to send telemetry data from the flight controller (the vehicle's attitude, battery, flight mode and GPS data) to the RC transmitter (Taranis).
 
@@ -182,7 +183,8 @@ Instructions for this are provided in the [TBS Crossfire Manual](https://www.tea
 
 The schematics are provided by [Airbot](https://myairbot.com/): [OmnibusF4-Pro-Sch.pdf](http://bit.ly/obf4pro).
 
-## PX4 Bootloader Update {#bootloader}
+<span id="bootloader"></span>
+## PX4 Bootloader Update
 
 The board comes pre-installed with [Betaflight](https://github.com/betaflight/betaflight/wiki). 
 Before PX4 firmware can be installed, the *PX4 bootloader* must be flashed.

--- a/en/flight_controller/pixhawk-2.md
+++ b/en/flight_controller/pixhawk-2.md
@@ -34,7 +34,8 @@ Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as
 * microSD card for high-rate logging over extended periods of time
 
 
-## Where to Buy {#stores}
+<span id="stores"></span>
+## Where to Buy
 
 [Cube Black](http://www.proficnc.com/61-system-kits) (ProfiCNC)
 
@@ -108,7 +109,8 @@ Board schematics and other documentation can be found here: [The Cube Project](h
 
 ![Cube Ports - Top (GPS, TELEM etc) and Main/AUX](../../assets/flight_controller/cube/cube_ports_top_main.jpg)
 
-### Serial Port Mapping {#serial_ports}
+<span id="serial_ports"></span>
+### Serial Port Mapping
 
 UART | Device | Port
 --- | --- | ---

--- a/en/flight_controller/pixhawk4.md
+++ b/en/flight_controller/pixhawk4.md
@@ -117,7 +117,8 @@ make px4_fmu-v5_default
 ```
 
 
-## Debug Port {#debug_port}
+<span id="debug_port"></span>
+## Debug Port
 
 The [PX4 System Console](https://dev.px4.io/master/en/debug/system_console.html) and [SWD interface](http://dev.px4.io/master/en/debug/swd_debug.html) run on the **FMU Debug** port, while the I/O console and SWD interface can be accessed via **I/O Debug** port.
 In order to access these ports, the user must remove the *Pixhawk 4* casing.

--- a/en/flight_controller/pixhawk_mini.md
+++ b/en/flight_controller/pixhawk_mini.md
@@ -173,7 +173,8 @@ Pixhawk Mini features an advanced processor and sensor technology from ST Microe
   - The defective Pixhawk Minis will not calibrate without an external magnetometer or an attached GPS, even indoor.
   - When using an external GPS, [this is not a problem](https://github.com/PX4/Firmware/pull/7618#issuecomment-320270082) because the secondary ICM20608 provides the accelerometer and the gyro, while the external GPS provides the magnetometer.
 
-## Wiring Quick Start {#wiring}
+<span id="wiring"></span>
+## Wiring Quick Start
 
 > **Warning** The *Pixhawk Mini* is no longer manufactured or available from 3DR.
 

--- a/en/flight_controller/pixhawk_series.md
+++ b/en/flight_controller/pixhawk_series.md
@@ -20,7 +20,8 @@ Key benefits of using a *Pixhawk series* controller include:
 * Automated update of latest firmware via *QGroundControl* (end-user friendly).
 
 
-## Supported Boards {#recommended}
+<span id="recommended"></span>
+## Supported Boards
 
 The PX4 Project uses [Pixhawk Standard Autopilots](../flight_controller/autopilot_pixhawk_standard.md) as reference hardware.
 These are the controllers that are fully compatible with the Pixhawk standard (including use of trademarks) and that are still being manufactured.
@@ -52,7 +53,8 @@ Manufacturers are encouraged to take the [open designs](https://github.com/pixha
 
 The project also creates reference autopilot boards based on the open designs, and shares them under the same [licence](#licensing-and-trademarks).
 
-### FMU Versions {#fmu_versions}
+<span id="fmu_versions"></span>
+### FMU Versions
 
 The Pixhawk project has created a number of different open designs/schematics.
 All boards based on a design should be binary compatible (run the same firmware).
@@ -78,7 +80,8 @@ At very high level, the main differences are:
 - **FMUv4-PRO:** Slightly increased RAM. More serial ports. IO processor ([Pixhawk 3 Pro](../flight_controller/pixhawk3_pro.md))
 - **FMUv5:** New processor (F7). Much faster. More RAM. More CAN busses. Much more configurable.([Pixhawk 4](../flight_controller/pixhawk4.md),[CUAV v5](../flight_controller/cuav_v5.md),[CUAV V5+](../flight_controller/cuav_v5_plus.md),[CUAV V5 nano](../flight_controller/cuav_v5_nano.md))
 
-### Licensing and Trademarks {#licensing-and-trademarks}
+<span id="licensing-and-trademarks"></span>
+### Licensing and Trademarks
 
 Pixhawk project schematics and reference designs are licensed under [CC BY-SA 3](https://creativecommons.org/licenses/by-sa/3.0/legalcode).
 

--- a/en/flight_modes/manual_stabilized_mc.md
+++ b/en/flight_modes/manual_stabilized_mc.md
@@ -21,7 +21,8 @@ The pilot's inputs are passed as roll and pitch angle commands and a yaw rate co
 > **Note**
 >  * Manual input is required (RC controller, or gamepad/thumbsticks through MAVLink).
 
-## Parameters {#params}
+<span id="params"></span>
+## Parameters
 
 Parameter | Description
 --- | ---

--- a/en/flight_modes/mission.md
+++ b/en/flight_modes/mission.md
@@ -66,7 +66,8 @@ Parameter | Description
 <span id="COM_RC_OVERRIDE"></span>[COM_RC_OVERRIDE](../advanced_config/parameter_reference.md#COM_RC_OVERRIDE) | If enabled, stick movement on a multicopter (or VTOL in multicopter mode) gives control back to the pilot in [Position mode](../flight_modes/position_mc.md) (except when vehicle is handling a critical battery failsafe). This can be separately enabled for auto modes and for offboard mode, and is enabled in auto modes by default.
 
 
-## Supported Mission Commands {#mission_commands}
+<span id="mission_commands"></span>
+## Supported Mission Commands
 
 PX4 "accepts" the following MAVLink mission commands in Mission mode (note: caveats below list).
 Unless otherwise noted, the implementation is as defined in the MAVLink specification.

--- a/en/flight_modes/return.md
+++ b/en/flight_modes/return.md
@@ -16,7 +16,8 @@ At the end there are sections explaining the *default* (preconfigured) behaviour
 > * RC stick movement in a multicopter (or VTOL in multicopter mode) will [by default](#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes/position_mc.md) unless handling a critical battery failsafe.
 
 
-## Return Types (RTL_TYPE) {#return_types}
+<span id="return_types"></span>
+## Return Types (RTL_TYPE)
 
 PX4 provides four alternative approaches ([RTL_TYPE](#RTL_TYPE)) for finding an unobstructed path to a safe destination and/or landing:
 - [Home/rally point return](#home_return) (`RTL_TYPE=0`): Ascend to safe altitude and return via a direct path to the closest rally point or home location.
@@ -30,7 +31,8 @@ PX4 provides four alternative approaches ([RTL_TYPE](#RTL_TYPE)) for finding an 
 
 More detailed explanations for each of the types are provided in the following sections.
 
-### Home/Rally Point Return Type (RTL_TYPE=0) {#home_return}
+<span id="home_return"></span>
+### Home/Rally Point Return Type (RTL_TYPE=0)
 
 In this return type the vehicle:
 - Ascends to a safe [return altitude](#return_altitude) (above any expected obstacles).
@@ -40,7 +42,8 @@ In this return type the vehicle:
 > **Note** If no rally points are defined, this is the same as a *Return to Launch* (RTL)/*Return to Home* (RTH).
 
 
-### Mission Landing/Rally Point Return Type (RTL_TYPE=1) {#mission_landing_return}
+<span id="mission_landing_return"></span>
+### Mission Landing/Rally Point Return Type (RTL_TYPE=1)
 
 In this return type the vehicle:
 - Ascends to a safe [return altitude](#return_altitude) (above any expected obstacles).
@@ -56,7 +59,8 @@ In this return type the vehicle:
 > **Warning** When this type is set PX4 will reject any mission without a valid landing pattern.
 
 
-### Mission Path Return Type (RTL_TYPE=2) {#mission_path_return}
+<span id="mission_path_return"></span>
+### Mission Path Return Type (RTL_TYPE=2)
 
 This return type uses the mission (if defined) to provide a safe return *path*, and the mission landing pattern (if defined) to provide landing behaviour.
 If there is a mission but no mission landing pattern, the mission is flown *in reverse*.
@@ -91,7 +95,8 @@ If no mission is defined PX4 will fly directly to home location and land (rally 
 If the mission changes during return mode, then the behaviour is re-evaluated based on the new mission following the same rules as above (e.g. if the new mission has no landing sequence and you're in a mission, the mission is reversed). 
 
 
-### Closest Safe Destination Return Type (RTL_TYPE=3) {#safety_point_return}
+<span id="safety_point_return"></span>
+### Closest Safe Destination Return Type (RTL_TYPE=3)
 
 In this return type the vehicle:
 - Ascends to a safe [return altitude](#return_altitude) (above any expected obstacles).
@@ -100,7 +105,8 @@ In this return type the vehicle:
 - If the destination is a home location or rally point, the vehicle will descend to the descent altitude ([RTL_DESCEND_ALT](#RTL_DESCEND_ALT)) and then [Land or waits](#arrival).
 
 
-## Return Altitude {#return_altitude}
+<span id="return_altitude"></span>
+## Return Altitude
 
 A vehicle will usually first ascend to a safe altitude before returning, in order to avoid any obstacles between it and the destination.
 
@@ -130,7 +136,8 @@ Note:
 
 
 
-## Hover/Landing at Destination {#arrival}
+<span id="arrival"></span>
+## Hover/Landing at Destination
 
 Unless executing a mission landing (e.g. if executing a [home location return](#home_return) or [closest safe destination return](#safety_point_return)), the vehicle will arrive at its destination, and rapidly descend to the [RTL_DESCEND_ALT](#RTL_DESCEND_ALT) altitude.
 
@@ -138,7 +145,8 @@ The vehicle will the loiter for a specified time ([RTL_LAND_DELAY](#RTL_LAND_DEL
 If [RTL_LAND_DELAY=-1](#RTL_LAND_DELAY) it will loiter indefinitely.
 
 
-## Vehicle Default Behaviour {#default_configuration}
+<span id="default_configuration"></span>
+## Vehicle Default Behaviour
 
 The mode is _implemented_ in almost exactly the same way in all vehicle types (the exception being that fixed wing vehicles will circle rather than hover when waiting), and are hence tuned using the same parameters.
 

--- a/en/flight_modes/takeoff.md
+++ b/en/flight_modes/takeoff.md
@@ -28,13 +28,15 @@ Parameter | Description
 <span id="MPC_TKO_SPEED"></span>[MPC_TKO_SPEED](../advanced_config/parameter_reference.md#MPC_TKO_SPEED) | Speed of ascent (default: 1.5m/s)
 <span id="COM_RC_OVERRIDE"></span>[COM_RC_OVERRIDE](../advanced_config/parameter_reference.md#COM_RC_OVERRIDE) | If enabled, stick movement on a multicopter (or VTOL in multicopter mode) gives control back to the pilot in [Position mode](../flight_modes/position_mc.md) (except when vehicle is handling a critical battery failsafe). This can be separately enabled for auto modes and for offboard mode, and is enabled in auto modes by default.
 
-## Fixed Wing (FW) {#fixed_wing}
+<span id="fixed_wing"></span>
+## Fixed Wing (FW)
 
 The aircraft takes off in the current direction using either *catapult/hand-launch mode* or *runway takeoff mode*.
 The mode defaults to catapult/hand launch, but can be set to runway takeoff using [RWTO_TKOFF](#RWTO_TKOFF).
 RC stick movement is ignored in both cases.
 
-### Catapult/Hand Launch {#hand_launch}
+<span id="hand_launch"></span>
+### Catapult/Hand Launch
 
 In *catapult/hand launch mode* the vehicle waits to detect launch (based on acceleration trigger).
 On launch it ramps up to full throttle ([RWTO_MAX_THR](#RWTO_MAX_THR)) in about 2 seconds and then performs a full throttle climbout, with *minimum* 10 degree takeoff pitch. 
@@ -43,7 +45,8 @@ Once it reaches [FW_CLMBOUT_DIFF](#FW_CLMBOUT_DIFF) it will transition to [Hold 
 > **Note** In addition to the behaviour discussed above there is also a launch detector that may block the launch sequence from starting until some condition is met.
   For catapult launch this is some acceleration threshold.
 
-### Runway Takeoff {#runway_launch}
+<span id="runway_launch"></span>
+### Runway Takeoff
 
 The *runway takeoff mode* has the following phases:
 

--- a/en/flying/basic_flying.md
+++ b/en/flying/basic_flying.md
@@ -5,7 +5,8 @@ This topic explains the basics of flying a vehicle using an [RC Transmitter](../
 > **Note** Before you fly for the first time you should read our [First Flight Guidelines](../flying/first_flight_guidelines.md).
 
 
-## Arm the Vehicle {#arm}
+<span id="arm"></span>
+## Arm the Vehicle
 
 Before you can fly the vehicle it must first be [armed](../getting_started/px4_basic_concepts.md#arming).
 This will power all motors and actuators; on a multicopter it will start propellers turning.

--- a/en/flying/terrain_following_holding.md
+++ b/en/flying/terrain_following_holding.md
@@ -7,7 +7,8 @@ PX4 also supports using a *distance sensor* as the [primary source of altitude d
 > **Note** PX4 does not "natively" support terrain following in missions.
   *QGroundControl* can be used to define missions that *approximately* follow terrain (this just sets waypoint altitudes based on height above terrain, where terrain height at waypoints is obtained from a map database).
 
-## Terrain Following {#terrain_following}
+<span id="terrain_following"></span>
+## Terrain Following
 
 *Terrain following* enables a vehicle to automatically maintain a relatively constant height above ground level when traveling at low altitudes.
 This is useful for avoiding obstacles and for maintaining constant height when flying over varied terrain (e.g. for aerial photography).
@@ -25,7 +26,8 @@ At higher altitudes (when the estimator reports that the distance sensor data is
 Terrain following is enabled by setting [MPC_ALT_MODE](../advanced_config/parameter_reference.md#MPC_ALT_MODE) to `1`.
 
 
-## Terrain Hold {#terrain_hold}
+<span id="terrain_hold"></span>
+## Terrain Hold
 
 *Terrain hold* uses a distance sensor to help a vehicle to better maintain a constant height above ground in altitude control modes, when horizontally stationary at low altitude.
 This allows a vehicle to avoid altitude changes due to barometer drift or excessive barometer interference from rotor wash.
@@ -41,7 +43,8 @@ Terrain holding is enabled by setting [MPC_ALT_MODE](../advanced_config/paramete
   If the distance to ground changes due to external forces, the altitude setpoint adjusts to keep the height above ground constant.
 
 
-## Distance Sensor as Primary Source of Height {#distance_sensor_primary_altitude_source}
+<span id="distance_sensor_primary_altitude_source"></span>
+## Distance Sensor as Primary Source of Height
 
 PX4 allows you to make a distance sensor the *primary source of altitude data* (in any flight mode/vehicle type).
 This may be useful when no barometer is available, or for applications when the vehicle is *guaranteed* to only fly over a near-flat surface (e.g. indoors).
@@ -64,7 +67,8 @@ When using a distance sensor as the primary source of height, fliers should be a
 The feature is enabled by setting: [EKF2_HGT_MODE=2](../advanced_config/parameter_reference.md#EKF2_HGT_MODE).
 
 
-## Range Aid {#range_aid}
+<span id="range_aid"></span>
+## Range Aid
 
 *Range Aid* uses a distance sensor as the primary source of height estimation during low speed/low altitude operation, but will otherwise use the primary source of altitude data defined in [EKF2_HGT_MODE](../advanced_config/parameter_reference.md#EKF2_HGT_MODE) (typically a barometer).
 It is primarily intended for *takeoff and landing*, in cases where the barometer setup is such that interference from rotor wash is excessive and can corrupt EKF state estimates.

--- a/en/frames_multicopter/dji_f450_cuav_5nano.md
+++ b/en/frames_multicopter/dji_f450_cuav_5nano.md
@@ -163,7 +163,8 @@ The final build is shown below:
 ![Finished Setup](../../assets/airframes/multicopter/dji_f450_cuav_5nano/f450_cuav5_nano_complete.jpg)
 
 
-## Vehicle Configuration/Calibration {#configure}
+<span id="configure"></span>
+## Vehicle Configuration/Calibration
 
 *QGroundControl* is used to install the PX4 autopilot and configure/tune it for the frame.
 [Download and install](http://qgroundcontrol.com/downloads/) 

--- a/en/frames_multicopter/dji_f450_cuav_5plus.md
+++ b/en/frames_multicopter/dji_f450_cuav_5plus.md
@@ -166,7 +166,8 @@ The final build is shown below:
 ![Finished Setup](../../assets/airframes/multicopter/dji_f450_cuav_5plus/f450_cuav5_plus_complete_2.jpg)
 
 
-## Vehicle Configuration/Calibration {#configure}
+<span id="configure"></span>
+## Vehicle Configuration/Calibration
 
 *QGroundControl* is used to install the PX4 autopilot and configure/tune it for the frame.
 [Download and install](http://qgroundcontrol.com/downloads/) 

--- a/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
+++ b/en/frames_multicopter/holybro_qav250_pixhawk4_mini.md
@@ -187,7 +187,8 @@ The steps to install the kit are:
   ![QAV250 FPV Wiring](../../assets/airframes/multicopter/qav250_holybro_pixhawk4_mini/fpv_connection.jpg)
 
 
-## Install/Configure PX4 {#configure}
+<span id="configure"></span>
+## Install/Configure PX4
 
 *QGroundControl* is used to install the PX4 autopilot and configure/tune it for the QAV250 frame.
 [Download and install](http://qgroundcontrol.com/downloads/) 

--- a/en/frames_multicopter/holybro_s500_v2_pixhawk4.md
+++ b/en/frames_multicopter/holybro_s500_v2_pixhawk4.md
@@ -259,7 +259,8 @@ Fully assembled, the kit looks as shown below:
 ![Fully Assembled](../../assets/airframes/multicopter/s500_holybro_pixhawk4/s500_assembled.jpg)
 
 
-## Install/Configure PX4 {#configure}
+<span id="configure"></span>
+## Install/Configure PX4
 
 *QGroundControl* is used to install the PX4 autopilot and configure/tune it for the QAV250 frame.
 [Download and install](http://qgroundcontrol.com/downloads/)

--- a/en/frames_multicopter/holybro_x500_pixhawk4.md
+++ b/en/frames_multicopter/holybro_x500_pixhawk4.md
@@ -257,7 +257,8 @@ Plugin Telemetry and GPS module to the flight controller as seen in Figure 20; p
 
 (Fully assembled X500 Kit)
 
-## Install/Configure PX4 {#configure}
+<span id="configure"></span>
+## Install/Configure PX4
 
 *QGroundControl* is used to install the PX4 autopilot and configure/tune it for the QAV250 frame.
 [Download and install](http://qgroundcontrol.com/downloads/)

--- a/en/frames_multicopter/qav_r_5_kiss_esc_racer.md
+++ b/en/frames_multicopter/qav_r_5_kiss_esc_racer.md
@@ -102,7 +102,8 @@ I tested all ESC motor pairs and their rotation directions using a cheap PWM ser
 
 ![Motor test](../../assets/airframes/multicopter/qav_r_5_kiss_esc_racer/motor-test.jpg)
 
-## Connecting & Mounting Electronics {#mounting}
+<span id="mounting"></span>
+## Connecting & Mounting Electronics
 
 > **Tip**
 > Double check the pin assignment of every component you connect. Sadly not every hardware component out there is plug and play even if it may look like this at first glance.

--- a/en/getting_started/flight_modes.md
+++ b/en/getting_started/flight_modes.md
@@ -21,7 +21,8 @@ PX4 will not allow transitions to those modes until the right conditions are met
 Last of all, in [autonomous modes](#categories) RC stick movement will [by default](../advanced_config/parameter_reference.md#COM_RC_OVERRIDE) change the vehicle to [Position mode](../flight_modes/position_mc.md) when flying as a multicopter (unless handling a critical battery failsafe). Stick movement is ignored for fixed-wing flight.
   
 
-## Autonomous and Manual Modes {#categories}
+<span id="categories"></span>
+## Autonomous and Manual Modes
 
 Flight Modes are, generally speaking, either *manual* or *autonomous*. 
 Manual modes are those where the user has control over vehicle movement via the RC control sticks (or joystick), while *autonomous* modes are fully controlled by the autopilot, and *require* no pilot/remote control input.
@@ -61,9 +62,11 @@ Icon | Description
 
 
 
-## Multicopter {#mc_flight_modes}
+<span id="mc_flight_modes"></span>
+## Multicopter
 
-### Position Mode {#position_mc}
+<span id="position_mc"></span>
+### Position Mode
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -75,7 +78,8 @@ When the sticks are released/centered the vehicle will actively brake, level, an
 ![MC Position Mode](../../assets/flight_modes/position_MC.png)
 
 
-### Altitude Mode {#altitude_mc}
+<span id="altitude_mc"></span>
+### Altitude Mode
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/altitude_icon.svg" title="Altitude required (e.g. Baro, Rangefinder)" width="30px" />](#altitude_only)
 
@@ -91,7 +95,8 @@ If the wind blows the aircraft will drift in the direction of the wind.
 ![MC Altitude Mode](../../assets/flight_modes/altitude_MC.png)
 
 
-### Manual/Stabilized Mode {#manual_stabilized_mc}
+<span id="manual_stabilized_mc"></span>
+### Manual/Stabilized Mode
 
 [<img src="../../assets/site/difficulty_medium.png" title="Medium difficulty to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -110,7 +115,8 @@ The craft will drift in the direction of any wind and you have to control the th
 ![MC Manual Flight](../../assets/flight_modes/manual_stabilized_MC.png)
 
 
-### Rattitude {#rattitude_mc}
+<span id="rattitude_mc"></span>
+### Rattitude
 
 [<img src="../../assets/site/difficulty_hard.png" title="Hard to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -122,7 +128,8 @@ When the sticks are centered the multicopter will level out (but will still drif
 <!-- Image missing: https://github.com/PX4/px4_user_guide/issues/189 -->
 
 
-### Acro Mode {#acro_mc}
+<span id="acro_mc"></span>
+### Acro Mode
 
 [<img src="../../assets/site/difficulty_hard.png" title="Hard to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -136,7 +143,8 @@ When sticks are centered the vehicle will stop rotating, but remain in its curre
 <!-- image above incorrect: https://github.com/PX4/px4_user_guide/issues/182 -->
 
 
-### Orbit Mode {#orbit_mc}
+<span id="orbit_mc"></span>
+### Orbit Mode
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -149,7 +157,8 @@ RC control is optional, and can be used to change the orbit altitude, radius, sp
 ![Orbit Mode - MC](../../assets/flight_modes/orbit_MC.png)
 
 
-### Hold Mode {#hold_mc}
+<span id="hold_mc"></span>
+### Hold Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -158,7 +167,8 @@ The mode can be used to pause a mission or to help regain control of a vehicle i
 It can be activated with a pre-programmed RC switch or the *QGroundControl* **Pause** button.
 
 
-### Return Mode {#return_mc}
+<span id="return_mc"></span>
+### Return Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -169,7 +179,8 @@ The return behaviour depends on parameter settings, and may follow a mission pat
 By default a mulitcopter will simply ascend to a safe height, fly to its home position, and then land. 
 
 
-### Mission Mode {#mission_mc}
+<span id="mission_mc"></span>
+### Mission Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -179,28 +190,32 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 > **Tip** The PX4 GCS is called [QGroundControl](https://docs.qgroundcontrol.com/en/). *QGroundControl* is the same application we use for [configuring PX4](../config/README.md).
 
 
-### Takeoff Mode {#takeoff_mc}
+<span id="takeoff_mc"></span>
+### Takeoff Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
 [Takeoff](../flight_modes/takeoff.md) mode causes the multicopter to climb vertically to takeoff altitude and hover in position.
 
 
-### Land Mode {#land_mc}
+<span id="land_mc"></span>
+### Land Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
 [Land mode](../flight_modes/land.md) causes the multicopter to land at the location at which the mode was engaged.
 
 
-### Follow Me Mode {#followme_mc}
+<span id="followme_mc"></span>
+### Follow Me Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
 [Follow Me mode](../flight_modes/follow_me.md) causes a multicopter to autonomously follow and track a user providing their current position setpoint.
 Position setpoints might come from an Android phone/tablet running *QGroundControl* or from a MAVSDK app.
 
-### Offboard Mode {#offboard_mc}
+<span id="offboard_mc"></span>
+### Offboard Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -209,9 +224,11 @@ Position setpoints might come from an Android phone/tablet running *QGroundContr
 > **Note** This mode is intended for companion computers and ground stations!
 
  
-## Fixed-Wing {#fw_flight_modes}
+<span id="fw_flight_modes"></span>
+## Fixed-Wing
 
-### Position Mode {#position_fw}
+<span id="position_fw"></span>
+### Position Mode
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -225,7 +242,8 @@ Pitch is used to ascend/descend. Roll, pitch and yaw are all angle-controlled (s
 ![FW Position Mode](../../assets/flight_modes/position_FW.png)
 
 
-### Altitude Mode {#altitude_fw}
+<span id="altitude_fw"></span>
+### Altitude Mode
 
 [<img src="../../assets/site/difficulty_easy.png" title="Easy to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;[<img src="../../assets/site/altitude_icon.svg" title="Altitude required (e.g. Barometer, Rangefinder)" width="30px" />](#altitude_only)
 
@@ -244,7 +262,8 @@ When all remote control inputs are centered (no roll, pitch, yaw, and ~50% throt
 ![FW Altitude Mode](../../assets/flight_modes/altitude_FW.png)
 
 
-### Stabilized Mode {#stabilized_fw}
+<span id="stabilized_fw"></span>
+### Stabilized Mode
 
 [<img src="../../assets/site/difficulty_medium.png" title="Medium difficulty to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -261,7 +280,8 @@ In order to perform a turn the command must beheld throughout the maneuver becau
 ![FW Manual Flight](../../assets/flight_modes/manual_stabilized_FW.png)
 
 
-### Acro Mode {#acro_fw}
+<span id="acro_fw"></span>
+### Acro Mode
 
 [<img src="../../assets/site/difficulty_hard.png" title="Hard to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -273,7 +293,8 @@ When sticks are centered the vehicle will stop rotating, but remain in its curre
 ![FW Manual Acrobatic Flight](../../assets/flight_modes/manual_acrobatic_FW.png)
 
 
-### Manual Mode {#manual_fw}
+<span id="manual_fw"></span>
+### Manual Mode
 
 [<img src="../../assets/site/difficulty_hard.png" title="Hard to fly" width="30px" />](#key_difficulty)&nbsp;[<img src="../../assets/site/remote_control.svg" title="Manual/Remote control required" width="30px" />](#key_manual)&nbsp;
 
@@ -287,7 +308,8 @@ When sticks are centered the vehicle will stop rotating, but remain in its curre
   It provides a safety mechanism that allows full control of throttle, elevator, ailerons and rudder via RC in the event of an FMU firmware malfunction.
 
 
-### Hold Mode {#hold_fw}
+<span id="hold_fw"></span>
+### Hold Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -296,7 +318,8 @@ The mode can be used to pause a mission or to help regain control of a vehicle i
 It can be activated with a pre-programmed RC switch or the *QGroundControl* **Pause** button.
 
 
-### Return Mode {#return_fw}
+<span id="return_fw"></span>
+### Return Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -307,7 +330,8 @@ The return behaviour depends on parameter settings, and may follow a mission pat
 By default a fixed wing vehicle will ascend to a safe height and use a mission landing pattern if one exists, otherwise it will fly to the home position and circle. 
 
 
-### Mission Mode {#mission_fw}
+<span id="mission_fw"></span>
+### Mission Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 
@@ -317,7 +341,8 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 > **Tip** The PX4 GCS is called [QGroundControl](https://docs.qgroundcontrol.com/en/). *QGroundControl* is the same application we use for [configuring PX4](../config/README.md).
 
 
-### Takeoff Mode {#takeoff_fw}
+<span id="takeoff_fw"></span>
+### Takeoff Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;
 
@@ -325,13 +350,15 @@ The mission is typically created and uploaded with a Ground Control Station (GCS
 The specific launch behaviour depends on the configured takeoff mode (catapult/hand-launch mode or runway takeoff mode).
 
 
-### Land Mode {#land_fw}
+<span id="land_fw"></span>
+### Land Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;
 
 [Land mode](../flight_modes/land.md) causes the vehicle to turn and land at the location at which the mode was engaged. Fixed wing landing logic and parameters are explained in the topic: [Landing (Fixed Wing)](../flying/fixed_wing_landing.md).
 
-### Offboard Mode {#offboard_fw}
+<span id="offboard_fw"></span>
+### Offboard Mode
 
 [<img src="../../assets/site/automatic_mode.svg" title="Automatic mode" width="30px" />](#key_automatic)&nbsp;[<img src="../../assets/site/position_fixed.svg" title="Position fix required (e.g. GPS)" width="30px" />](#key_position_fixed)
 

--- a/en/getting_started/led_meanings.md
+++ b/en/getting_started/led_meanings.md
@@ -5,7 +5,8 @@
 - The [Status LEDs](#status_led) provide status for the PX4IO and FMU SoC.
   They indicate power, bootloader mode and activity, and errors.
 
-## UI LED {#ui_led}
+<span id="ui_led"></span>
+## UI LED
 
 The RGB *UI LED* indicates the current *readiness for flight* status of the vehicle. 
 This is typically a superbright I2C peripheral, which may or may not be mounted on the flight controller board (i.e. FMUv4 does not have one on board, and typically uses an LED mounted on the GPS).
@@ -52,7 +53,8 @@ Attach your autopilot to a Ground Control Station to verify what the problem is.
 If you have completed the setup process and autopilot still appears as red and flashing, there may be another error.
 
 
-## Status LED {#status_led}
+<span id="status_led"></span>
+## Status LED
 
 Three *Status LEDs* provide status for the FMU SoC, and three more provide status for the PX4IO (if present). 
 They indicate power, bootloader mode and activity, and errors.

--- a/en/getting_started/px4_basic_concepts.md
+++ b/en/getting_started/px4_basic_concepts.md
@@ -19,7 +19,8 @@ The "brain" of the drone is called an autopilot.
 It consists of *flight stack* software running on *vehicle controller* ("flight controller") hardware.
 
 
-## PX4 Autopilot {#autopilot}
+<span id="autopilot"></span>
+## PX4 Autopilot
 
 [PX4](http://px4.io/) is powerful open source autopilot *flight stack*. 
 
@@ -31,7 +32,8 @@ Some of PX4's key features are:
 PX4 is a core part of a broader drone platform that includes the [QGroundControl](#qgc) ground station, [Pixhawk hardware](https://pixhawk.org/), and [MAVSDK](http://mavsdk.mavlink.io) for integration with companion computers, cameras and other hardware using the MAVLink protocol.
 PX4 is supported by the [Dronecode Project](https://www.dronecode.org/).
 
-## QGroundControl {#qgc}
+<span id="qgc"></span>
+## QGroundControl
 
 The Dronecode ground control station is called [QGroundControl](http://qgroundcontrol.com/).
 You can use *QGroundControl* to load (flash) PX4 onto the [vehicle control hardware](flight_controller_selection.md), you can setup the vehicle, change different parameters, get real-time flight information and create and execute fully autonomous missions.
@@ -40,7 +42,8 @@ You can use *QGroundControl* to load (flash) PX4 onto the [vehicle control hardw
 
 ![QGC Main Screen](../../assets/concepts/qgc_main_screen.jpg)
 
-## Vehicle/Flight Controller Board {#vehicle_controller}
+<span id="vehicle_controller"></span>
+## Vehicle/Flight Controller Board
 
 PX4 was initially designed to run on [Pixhawk Series](../flight_controller/pixhawk_series.md) controllers, but can now run on Linux computers and other hardware.
 You should select a board that suits the physical constraints of your vehicle, the activities you wish to perform, and of course cost.
@@ -58,7 +61,8 @@ For more information see:
 * [Peripherals](../peripherals/README.md)
 
 
-## Outputs: Motors, Servos, Actuators {#outputs}
+<span id="outputs"></span>
+## Outputs: Motors, Servos, Actuators
 
 PX4 uses *outputs* to control: motor speed (e.g. via [ESC](#esc_and_motors)), flight surfaces like ailerons and flaps, camera triggers, parachutes, grippers, and many other types of payloads.
 
@@ -97,7 +101,8 @@ The (same) airframe mapping of outputs to nodes is used in this case.
   In theory there can be many more outputs if the bus supports it (i.e. a UAVCAN bus is not limited to this few nodes).
 
 
-## ESCs & Motors {#esc_and_motors}
+<span id="esc_and_motors"></span>
+## ESCs & Motors
 
 Many PX4 drones use brushless motors that are driven by the flight controller via an Electronic Speed Controller (ESC) 
 (the ESC converts a signal from the flight controller to an appropriate level of power delivered to the motor).
@@ -118,7 +123,8 @@ Information about batteries and battery configuration can be found in [Battery C
 and the guides in [Basic Assembly](../assembly/README.md) (e.g. [Pixhawk 4 Wiring Quick Start > Power](../assembly/quick_start_pixhawk4.md#power)).
 
 
-## Radio Control (RC) {#rc_systems}
+<span id="rc_systems"></span>
+## Radio Control (RC)
 
 A [Radio Control \(RC\)](../getting_started/rc_transmitter_receiver.md) system is used to *manually* control the vehicle. 
 It consists of a remote control unit that uses a transmitter to communicate stick/control positions with a receiver based on the vehicle. 
@@ -133,7 +139,8 @@ Some RC systems can additionally receive telemetry information back from the aut
 * [Flying 101](../flying/basic_flying.md) - Learn how to fly with a remote control.
 * [FrSky Telemetry](../peripherals/frsky_telemetry.md) - Set up the RC transmitter to receive telemetry/status updates from PX4.
 
-## GCS Joystick Controller {#joystick}
+<span id="joystick"></span>
+## GCS Joystick Controller
 
 A [computer joystick](../config/joystick.md) connected through *QGroundControl* can also be used to manually control PX4 (QGC converts joystick movements into MAVLink messages that are sent over the telemetry link).
 This approach is used by ground control units that have an integrated ground control station, like the *UAVComponents* [MicroNav](https://www.uavcomp.com/command-control/micronav/) shown below.
@@ -142,7 +149,8 @@ Joysticks are also commonly used to fly the vehicle in simulation.
 ![Joystick MicroNav.](../../assets/peripherals/joystick/micronav.jpg)
 
 
-## Safety Switch {#safety_switch}
+<span id="safety_switch"></span>
+## Safety Switch
 
 It is common for vehicles to have a *safety switch* that must be engaged before the vehicle can be [armed](#arming) (when armed, motors are powered and propellers can turn).
 Commonly the safety switch is integrated into a GPS unit, but it may also be a separate physical component.
@@ -167,7 +175,8 @@ The companion computer will usually communicate using a MAVLink API like the MAV
 * [Robotics APIs](https://dev.px4.io/master/en/robotics/) (PX4 Developer Guide)
 
 
-## SD Cards (Removable Memory) {#sd_cards}
+<span id="sd_cards"></span>
+## SD Cards (Removable Memory)
 
 PX4 uses SD memory cards for storing [flight logs](../getting_started/flight_reporting.md), and they are also required in order to use UAVCAN peripherals and fly [missions](../flying/missions.md).
 
@@ -184,7 +193,8 @@ Flight controllers that do not include an SD Card slot may:
   <!-- Too low-level for this. But see FLASH_BASED_DATAMAN in  Intel Aero: https://github.com/PX4/Firmware/blob/master/boards/intel/aerofc-v1/src/board_config.h#L115 -->
 
 
-## Arming and Disarming {#arming}
+<span id="arming"></span>
+## Arming and Disarming
 
 Vehicles may have moving parts, some of which are potentially dangerous when powered (in particular motors and propellers)!
 
@@ -201,7 +211,8 @@ It is also possible to configure PX4 to arm using an RC button on the RC control
 A detailed overview of arming and disarming configuration can be found here: [Prearm, Arm, Disarm Configuration](../advanced_config/prearm_arm_disarm.md).
 
 
-## Flight Modes {#flight_modes}
+<span id="flight_modes"></span>
+## Flight Modes
 
 Flight modes provide different types/levels of vehicle automation and autopilot assistance to the user (pilot). 
 *Autonomous modes* are fully controlled by the autopilot, and require no pilot/remote control input. 
@@ -218,7 +229,8 @@ An overview of the available flight modes [can be found here](../getting_started
 Instructions for how to set up your remote control switches to turn on different flight modes is provided in [Flight Mode Configuration](../config/flight_mode.md).
 
 
-## Safety Settings (Failsafe) {#safety}
+<span id="safety"></span>
+## Safety Settings (Failsafe)
 
 PX4 has configurable failsafe systems to protect and recover your vehicle if something goes wrong! 
 These allow you to specify areas and conditions under which you can safely fly, and the action that will be performed if a failsafe is triggered (for example, landing, holding position, or returning to a specified point).

--- a/en/getting_started/rc_transmitter_receiver.md
+++ b/en/getting_started/rc_transmitter_receiver.md
@@ -31,7 +31,8 @@ Ground vehicles need at least two channels (steering + throttle). An 8 or 16 cha
 
 ## Types of Remote Controls
 
-### Remote Control Units for Aircraft {#transmitter_modes}
+<span id="transmitter_modes"></span>
+### Remote Control Units for Aircraft
 
 The most popular *form* of remote control unit for UAVs is shown below.
 It has separate control sticks for controlling roll/pitch and for throttle/yaw as shown (i.e. aircraft need at least 4 channels).
@@ -79,7 +80,8 @@ Other popular transmitter/receiver pairs
 * Long Range ~433MHz: ImmersionRC EzUHF set with a compatible remote (e.g. Taranis)
 
 
-### PX4-Compatible Receivers {#compatible_receivers}
+<span id="compatible_receivers"></span>
+### PX4-Compatible Receivers
 
 In addition to the transmitter/receiver pairs being compatible, the receiver must also be compatible with PX4 and the flight controller hardware.
 
@@ -110,7 +112,8 @@ Instructions for connecting to specific flight controllers are given in the foll
 > **Tip** See the manufacturer's flight controller setup guide for additional information.
 
 
-## Binding Transmitter/Receiver {#binding}
+<span id="binding"></span>
+## Binding Transmitter/Receiver
 
 Before you can calibrate/use a radio system you must *bind* the receiver and transmitter so that they communicate only with each other.
 The process for binding a transmitter and receiver pair is hardware specific (see your manual for instructions).

--- a/en/getting_started/sensor_selection.md
+++ b/en/getting_started/sensor_selection.md
@@ -9,7 +9,8 @@ The minimal set of sensors is incorporated into [Pixhawk Series](../flight_contr
 Below we describe some of the sensors. At the end there are links to information about [sensor wiring](#wiring).
 
 
-## GPS & Compass {#gps_compass}
+<span id="gps_compass"></span>
+## GPS & Compass
 
 PX4 supports a number of global navigation satellite system (GNSS) receivers and compasses (magnetometers). 
 It also supports [Real Time Kinematic (RTK) GPS Receivers](../gps_compass/rtk_gps.md), which extend GPS systems to centimetre-level precision.
@@ -66,7 +67,8 @@ Some options include:
 * [HK Pilot32 Optical Flow Kit With Sonar](https://hobbyking.com/en_us/hk-pilot32-optical-flow-kit-with-sonar.html) (Hobbyking) - Software-compatible, but not connector-compatible.
 
 
-## Sensor Wiring {#wiring}
+<span id="wiring"></span>
+## Sensor Wiring
 
 Sensor wiring information is usually provided in manufacturer documentation for flight controllers and the sensors themselves.
 

--- a/en/getting_started/tunes.md
+++ b/en/getting_started/tunes.md
@@ -89,7 +89,8 @@ Your browser does not support the audio element.
 
 These tones/tunes are emitted during normal operation.
 
-#### Error Tune {#error_tune_operational}
+<span id="error_tune_operational"></span>
+#### Error Tune
 <audio controls>
   <source src="../../assets/tunes/2_error_tune.mp3" type="audio/mpeg">
 Your browser does not support the audio element.

--- a/en/gps_compass/README.md
+++ b/en/gps_compass/README.md
@@ -68,7 +68,8 @@ GPS configuration on Pixhawk is handled transparently for the user - simply conn
   If you are using the *Trimble MB-Two* you will need to modify the configuration to explicitly set the rate to 115200 baud.
 
 
-### Secondary GPS (Dual GPS System) {#dual_gps}
+<span id="dual_gps"></span>
+### Secondary GPS (Dual GPS System)
 
 To use a secondary GPS, attach it to any free port, and then perform a [Serial Port Configuration](../peripherals/serial_configuration.md) to assign [GPS_2_CONFIG](../advanced_config/parameter_reference.md#GPS_2_CONFIG) to the selected port.
 

--- a/en/gps_compass/rtk_gps_holybro_h-rtk-m8p.md
+++ b/en/gps_compass/rtk_gps_holybro_h-rtk-m8p.md
@@ -25,7 +25,8 @@ All H-RTK GNSS models come with a GH 10-pin connector/cable that is compatible w
 
 > **Note** The cables/connectors may need to be modified in order to connect to other flight controller boards (see [pin map](#pin_map)below).
 
-## Pin Map {#pin_map}
+<span id="pin_map"></span>
+## Pin Map
 
 ![h-rtk_rover_pinmap](../../assets/hardware/gps/rtk_holybro_h-rtk-m8p_pinmap.jpg)
 

--- a/en/log/flight_log_analysis.md
+++ b/en/log/flight_log_analysis.md
@@ -110,7 +110,8 @@ Key features:
 ![pyFlightAnalysis 1.0.1b1](../../assets/flight_log_analysis/pyflightanalysis.png)
 
 
-### FlightPlot {#flightplot}
+<span id="flightplot"></span>
+### FlightPlot
 
 [FlightPlot](https://github.com/PX4/FlightPlot) is a desktop based tool for log analysis. It can be downloaded from [FlightPlot Downloads](https://github.com/PX4/FlightPlot/releases) (Linux, MacOS, Windows).
 

--- a/en/log/flight_review.md
+++ b/en/log/flight_review.md
@@ -17,7 +17,8 @@ Features that are common to many plots:
 - Mouse scrolling on a particular plot axis zooms that axis (horizontally or vertically).
 - Mouse scrolling inside the plot zooms both axes.
 
-## PID Tracking Performance {#tracking}
+<span id="tracking"></span>
+## PID Tracking Performance
 
 Depending on the flight mode, the vehicle controllers may attempt to track position, velocity, altitude or rate setpoints (the tracked setpoints depend on the mode, e.g.: in Stabilized mode there is no velocity setpoint).
 
@@ -180,7 +181,8 @@ Very high (unsafe) vibration levels.
 ![Exceedingly high vibration in raw accel. plot](../../assets/flight_log_analysis/flight_review/vibrations_exceedingly_high_accel.png)
 
 
-### Raw High-rate IMU Data Plots {#fifo_logging}
+<span id="fifo_logging"></span>
+### Raw High-rate IMU Data Plots
 
 For an in-depth analysis there is an option to log the raw IMU data at full rate (several kHz, depending on the IMU).
 This allows inspection of much higher frequencies than with normal logging, which can help when selecting vibration mounts or configuring low-pass and notch filters appropriately.
@@ -207,7 +209,8 @@ Example plot:
 <span></span>
 > **Note** Do not forget to restore the parameters after testing.
 
-### Fixing Vibration Problems {#solutions}
+<span id="solutions"></span>
+### Fixing Vibration Problems
 
 Often a source of vibration (or combination of multiple sources) cannot be identified from logs alone.
 

--- a/en/peripherals/companion_computer_peripherals.md
+++ b/en/peripherals/companion_computer_peripherals.md
@@ -58,7 +58,8 @@ The following sensors can be used for [Visual Inertial Odometry (VIO)](../comput
 - [T265 Realsense Tracking Camera](../peripherals/camera_t265_vio.md)
 
 
-## Data Telephony (LTE) {#data_telephony}
+<span id="data_telephony"></span>
+## Data Telephony (LTE)
 
 An LTE USB module can be attached to a companion computer and used to route MAVLink traffic between the flight controller and the Internet.
 

--- a/en/peripherals/dshot.md
+++ b/en/peripherals/dshot.md
@@ -11,7 +11,8 @@ DShot is an alternative ESC protocol that has several advantages over PWM or One
 This topic shows how to connect and configure DShot ESCs.
 
 
-## Wiring/Connections {#wiring}
+<span id="wiring"></span>
+## Wiring/Connections
 
 DShot ESCs are connected and wired the same way as [PWM ESCs](pwm_escs_and_servo.md), and you can switch between these protocols just by changing software parameters (ESCs automatically detect the selected protocol on startup).
 
@@ -35,7 +36,8 @@ If using a Pixhawk that has ports labeled AUX and MAIN, set [SYS_USE_IO=0](../ad
 > **Tip** You can't mix DShot ESCs/servos and PWM ESCs/servos on the FMU (DShot is enabled/disabled for *all* FMU pins on the port). 
 
 
-## Configuration {#configuration}
+<span id="configuration"></span>
+## Configuration
 
 > **Warning** Remove propellers before changing ESC configuration parameters!
 
@@ -50,7 +52,8 @@ The ESCs should initialize and the motors turn in the correct directions.
 - Adjust [DSHOT_MIN](../advanced_config/parameter_reference.md#DSHOT_MIN) so that the motors spin at lowest throttle (but the vehicle does not take off).
 
 
-## ESC Commands {#commands}
+<span id="commands"></span>
+## ESC Commands
 
 Commands can be sent to the ESC via the [MAVLink shell](https://dev.px4.io/master/en/debug/mavlink_shell.html).
 See [here](https://dev.px4.io/master/en/middleware/modules_driver.html#dshot) for a full reference of the supported commands.

--- a/en/peripherals/frsky_telemetry.md
+++ b/en/peripherals/frsky_telemetry.md
@@ -49,7 +49,8 @@ For Pixhawk FMUv5 and later PX4 can read either inverted (or uninverted) S.Port 
 Simply attach one of the UART's TX pins to the SPort inverted or uninverted pin (PX4 will auto-detect and handle either type).
 Then [configure PX4](#configure).
   
-## PX4 Configuration {#configure}
+<span id="configure"></span>
+## PX4 Configuration
 
 [Configure the serial port](../peripherals/serial_configuration.md) on which FrSky will run using [TEL_FRSKY_CONFIG](../advanced_config/parameter_reference.md#TEL_FRSKY_CONFIG). 
 There is no need to set the baud rate for the port, as this is configured by the driver.
@@ -65,7 +66,8 @@ There is no need to set the baud rate for the port, as this is configured by the
 No further configuration is required; FrSky telemetry auto-starts when connected and detects D or S mode.
 
 
-## Compatible RC Transmitters {#transmitters}
+<span id="transmitters"></span>
+## Compatible RC Transmitters
 
 You will need an RC transmitter that can receive the telemetry stream (and that is bound to the FrSky receiver). 
 
@@ -91,12 +93,14 @@ If you open the `LuaPil.lua` script with a text editor, you can edit the configu
 * `local SayFlightMode = 0` - There are no WAV files for the PX4 flight modes
 
 
-## Telemetry Messages {#messages}
+<span id="messages"></span>
+## Telemetry Messages
 
 FrySky Telemetry can transmit most of the more useful status information from PX4.
 S-Port and D-Port receivers transmit different sets of messages, as listed in the following sections.
 
-### S-Port {#s_port}
+<span id="s_port"></span>
+### S-Port
 
 S-Port receivers transmit the following messages from PX4 (from [here](https://github.com/iNavFlight/inav/blob/master/docs/Telemetry.md#available-smartport-sport-sensors)):
 
@@ -144,7 +148,8 @@ D-Port receivers transmit the following messages (from [here](https://github.com
 - **Vspd:** Vertical speed (cm/s).
 
 
-## FrSky Telemetry Receivers {#receivers}
+<span id="receivers"></span>
+## FrSky Telemetry Receivers
 
 Pixhawk/PX4 supports D (old) and S (new) FrSky telemetry. The table belows all FrSky receivers that support telemetry via a D/S.PORT (in theory all of these should work). 
 
@@ -171,7 +176,8 @@ R9 slim | 10km | S.Bus (16) | Smart Port | 43.3x26.8x13.9mm | 15.8g
 
 > **Note** The above table originates from http://www.redsilico.com/frsky-receiver-chart and FrSky [product documentation](https://www.frsky-rc.com/product-category/receivers/).
 
-## Ready-Made Cables {#ready_made_cable}
+<span id="ready_made_cable"></span>
+## Ready-Made Cables
 
 Ready-made cables for use with Pixhawk FMUv4 and earlier (except for Pixracer) are available from:
 * [Craft and Theory](http://www.craftandtheoryllc.com/telemetry-cable). Versions are available with DF-13 compatible *PicoBlade connectors* (for FMUv2/3DR Pixhawk, FMUv2/HKPilot32) and *JST-GH connectors* (for FMUv3/Pixhawk 2 "The Cube" and FMUv4/PixRacer v1).
@@ -179,7 +185,8 @@ Ready-made cables for use with Pixhawk FMUv4 and earlier (except for Pixracer) a
   <a href="http://www.craftandtheoryllc.com/telemetry-cable"><img src="../../assets/hardware/telemetry/craft_and_theory_frsky_telemetry_cables.jpg" alt="Purchase cable here from Craft and Theory"></a>
 
 
-## DIY Cables {#diy_cables}
+<span id="diy_cables"></span>
+## DIY Cables
 
 It is possible to create your own adapter cables.
 You will need connectors that are appropriate for your autopilot (e.g. *JST-GH connectors* for FMUv3/Pixhawk 2 "The Cube" and FMUv4/PixRacer v1, and DF-13 compatible *PicoBlade connectors* for older autopilots).
@@ -224,7 +231,8 @@ You will need to connect via a UART to S.PORT adapter board, or a [ready-made ca
 Simply attach one of the UART's TX pins to the SPort inverted or uninverted pin (PX4 will auto-detect and handle either type).
 
 
-### Other Boards {#pixhawk_v2}
+<span id="pixhawk_v2"></span>
+### Other Boards
 
 Most other boards connect to the receiver for FrSky telemetry via the TELEM2 UART. 
 This includes, for example: [Pixhawk 1](../flight_controller/pixhawk.md), [mRo Pixhawk](../flight_controller/mro_pixhawk.md), Pixhawk2. 

--- a/en/peripherals/mavlink_peripherals.md
+++ b/en/peripherals/mavlink_peripherals.md
@@ -47,7 +47,8 @@ The parameter used will depend on the [assigned serial port](../advanced_config/
 The value you use will depend on the type of connection and the capabilities of the connected MAVLink peripheral.
 
 
-## Default MAVLink Ports {#default_ports}
+<span id="default_ports"></span>
+## Default MAVLink Ports
 
 The `TELEM 1` port is almost always used for the GCS telemetry stream.
 

--- a/en/peripherals/parachute.md
+++ b/en/peripherals/parachute.md
@@ -50,7 +50,8 @@ Motor settings:
 > **Note** There is no way to recover from a Termination state!
   Reboot/power cycle the vehicle before your next test.
 
-## Parachute Testing {#testing}
+<span id="testing"></span>
+## Parachute Testing
 
 The parachute will trigger during [flight termination](../advanced_config/flight_termination.md).
 

--- a/en/peripherals/serial_configuration.md
+++ b/en/peripherals/serial_configuration.md
@@ -10,7 +10,8 @@ The configuration makes it easy to (for example):
 
 > **Note** Some ports cannot be configured because they are used for a very specific purpose like RC input or the system console (`SERIAL 5`).
 
-## Pre-configured Ports {#default_port_mapping}
+<span id="default_port_mapping"></span>
+## Pre-configured Ports
 
 The following functions are typically mapped to the same specific serial ports on all boards, and are hence mapped by default:
 
@@ -44,7 +45,8 @@ Port conflicts are handled by system startup, which ensures that at most one ser
 
 ## Troubleshooting
 
-### Configuration Parameter Missing from *QGroundControl* {#parameter_not_in_firmware}
+<span id="parameter_not_in_firmware"></span>
+### Configuration Parameter Missing from *QGroundControl*
 
 *QGroundControl* only displays the parameters for services/drivers that are present in firmware.
 If a parameter is missing, then you may need to add it in firmware.

--- a/en/peripherals/uavcan_escs.md
+++ b/en/peripherals/uavcan_escs.md
@@ -53,7 +53,8 @@ Mitochondrik based drives and ESC:
 > **Note** There are many other commercially available ESCs; please add new links as you find them!
 
 
-## Wiring/Connections {#connecting}
+<span id="connecting"></span>
+## Wiring/Connections
 
 Connect all of the on-board UAVCAN devices into a chain and make sure the bus is terminated at the end nodes.
 The order in which the ESCs are connected/chained does not matter.
@@ -88,12 +89,14 @@ The mechanism for enumerating each type of UAVCAN ESC is different (look up the 
 Setup information for some UAVCAN ESCs is provided below.
 
 
-### Sapog ESC setup {#sapog}
+<span id="sapog"></span>
+### Sapog ESC setup
 
 The following sections explain how to enumerate [Sapog-based](https://github.com/PX4/sapog#px4-sapog)-based ESCs with PX4.
 The instructions should work for any Sapog-based ESC design.
 
-#### ESC Enumeration using QGroundControl {#sapog_esc_qgc}
+<span id="sapog_esc_qgc"></span>
+#### ESC Enumeration using QGroundControl
 
 > **Tip** You can skip this section if there is only one ESC in your setup, because the ESC index is already set to zero by default.
 

--- a/en/sensor/avanon_laser_interface.md
+++ b/en/sensor/avanon_laser_interface.md
@@ -8,7 +8,8 @@ The [Avionics Anonymous Laser Altimeter Interface](https://www.tindie.com/produc
 
 * [AvAnon Laser Interface](https://www.tindie.com/products/avionicsanonymous/uavcan-laser-altimeter-interface/)
 
-## Supported Rangefinders {#supported_rangefinders}
+<span id="supported_rangefinders"></span>
+## Supported Rangefinders
 
 A full list supported rangefinders can be found on the link above. 
 

--- a/en/sensor/optical_flow.md
+++ b/en/sensor/optical_flow.md
@@ -52,7 +52,8 @@ However we recommend using LIDAR rather than sonar sensors, because of their rob
 
 ## Estimators
 
-### Extended Kalman Filter (EKF2) {#ekf2}
+<span id="ekf2"></span>
+### Extended Kalman Filter (EKF2)
 
 For optical flow fusion using EKF2, set the use optical flow flag in the [EKF2_AID_MASK](../advanced_config/parameter_reference.md#EKF2_AID_MASK) parameter, as shown using QGroundControl below:
 

--- a/en/sensor/pmw3901.md
+++ b/en/sensor/pmw3901.md
@@ -24,7 +24,8 @@ Thone | [ThoneFlow-3901U](#thone_thoneflow_3901U) | UART | Y | - | - | 3 - 5 | A
 Alientek | [ATK-PMW3901](#alientek_atk-pwm3901) | SPI | Y | - | - | 3.3 - 4.2 | 27.5x16.5 | 1
 
 
-## External Rangefinders {#external_rangefinder}
+<span id="external_rangefinder"></span>
+## External Rangefinders
 
 An external rangefinder/distance sensor is *required* for the sensors that don't have a rangefinder (e.g. *Tindie* or *Thone*) and *recommended* for the other boards (as their range is quite limited).
 
@@ -38,7 +39,8 @@ The sensor can be mounted anywhere but must point down, and should be connected/
 > **Tip** The PX4 team mainly tested using the [Lidar Lite V3](../sensor/lidar_lite.md) on larger vehicles and the [Lanbao CM8JL65](../sensor/cm8jl65_ir_distance_sensor.md) on smaller vehicles.
 
 
-## Mounting/Orientation {#orientation}
+<span id="orientation"></span>
+## Mounting/Orientation
 
 Flow modules are typically mounted near the centre of the vehicle.
 If mounted off-centre you will need to set offsets: [Optical Flow > EKF2](../sensor/optical_flow.md#ekf2).
@@ -60,7 +62,8 @@ Tindie<br>![PMW3901 Tindie Notch](../../assets/hardware/sensors/pmw3901/tindie_n
 Thone<br>![PMW3901 Thoneflow Notch](../../assets/hardware/sensors/pmw3901/thoneflow_3901u_notch.jpg) | Alientek (also has an arrow indicating the front!)<br>![PMW3901 Alientek Notch](../../assets/hardware/sensors/pmw3901/alientek_pmw3901_notch.jpg)
 
 
-## PX4 Configuration {#configuration}
+<span id="configuration"></span>
+## PX4 Configuration
 
 The PX4 configuration that is common to all boards:
 - [Optical Flow > EKF2](../sensor/optical_flow.md#ekf2) explains how to fuse optical flow data in the EKF2 estimator and set position offsets for the mounting position of the flow sensor.
@@ -71,7 +74,8 @@ In addition:
 - Individual flow sensors are setup/configured as described in the sections below.
 
 
-## Bitcraze Flow breakout {#bitcraze_flow_breakout}
+<span id="bitcraze_flow_breakout"></span>
+## Bitcraze Flow breakout
 
 The [Bitcraze Flow breakout](https://www.bitcraze.io/products/flow-breakout/) directly exposes the [SPI interface](#spi_wiring) from the PMW3901 module.
 
@@ -83,7 +87,8 @@ We therefore highly recommend that you use an [external distance sensor](#extern
 ![Bitcraze Flow Deck](../../assets/hardware/sensors/pmw3901/bitcraze-flow.jpg)
 
 
-### SPI Wiring {#spi_wiring}
+<span id="spi_wiring"></span>
+### SPI Wiring
 
 The PMW3901 driver was written such that the board can be directly plugged into the SPI port on the Pixhawk 4 using the chip select 1.
 When plugged into the SPI port of the Pixhawk 4, the Bitcraze flow module will be automatically detected at bootup.
@@ -109,13 +114,15 @@ The following diagram shows how to wire the sensor to a Pixhawk 4.
 ![Bitcraze PH4 Pinout](../../assets/hardware/sensors/pmw3901/ph4-bitcraze-flow-pinout.png)
 
 
-### I2C Wiring {#i2c_wiring}
+<span id="i2c_wiring"></span>
+### I2C Wiring
 
 The I2C wiring is the same for any other distance sensor.
 Simply connect the SLA, SLC, GND and VCC to the corresponding (same) pins on the Pixhawk and the sensor. 
 
 
-## Tindie PMW3901 Optical Flow Sensor {#tindie_pmw3901_flow_sensor}
+<span id="tindie_pmw3901_flow_sensor"></span>
+## Tindie PMW3901 Optical Flow Sensor
 
 The Tindie [PMW3901 Optical Flow Sensor](https://www.tindie.com/products/onehorse/pmw3901-optical-flow-sensor/) exposes the SPI interface from the PMW3901 module exactly as on the Bitcraze module (see [SPI Wiring](#spi_wiring)).
 
@@ -124,7 +131,8 @@ The Tindie [PMW3901 Optical Flow Sensor](https://www.tindie.com/products/onehors
 The sensor doesn't have a distance sensor onboard so you will need to use an [external distance sensor](#external_rangefinder).
 
 
-## AlienTek ATK-PMW3901 {#alientek_atk-pwm3901}
+<span id="alientek_atk-pwm3901"></span>
+## AlienTek ATK-PMW3901
 
 The AlienTek [ATK-PMW3901](https://www.aliexpress.com/i/32979605707.html) exposes the SPI interface from the PMW3901 module in the same way as the Bitcraze module (see [SPI Wiring](#spi_wiring)).
 
@@ -137,7 +145,8 @@ A screenshot showing the I2C pins (SLA, SLC, GND and VCC) is provided below.
 ![Alientek Pinout](../../assets/hardware/sensors/pmw3901/alientek.png)
 
 
-## Hex HereFlow PMW3901 Optical Flow Sensor {#hex_hereflow_pwm3901}
+<span id="hex_hereflow_pwm3901"></span>
+## Hex HereFlow PMW3901 Optical Flow Sensor
 
 The Hex [HereFlow PMW3901 Optical Flow Sensor](http://www.proficnc.com/all-products/185-pixhawk2-suite.html) is a very small board containing the PMW3901 flow module, the VL53L1X distance sensor and an IMU to better synchronize the flow data with the gyro data.
 
@@ -148,7 +157,8 @@ The board can be connected to any CAN port on any Pixhawk board (see [UAVCAN wir
 As for the other optical flow boards, we recommend thatyou use an [external distance sensor](#external_rangefinder).
 
 
-### UAVCAN Wiring/Setup {#uavcan_wiring}
+<span id="uavcan_wiring"></span>
+### UAVCAN Wiring/Setup
 
 The diagram below shows how to connect the sensor to the Pixhawk 4 CAN bus.
 
@@ -159,7 +169,8 @@ In addition to any other configuration, you will need to set the parameter [UAVC
 - `UAVCAN_ENABLE=3`: UAVCAN sensors and motor controllers.
 
 
-## Thone ThoneFlow-3901U {#thone_thoneflow_3901U}
+<span id="thone_thoneflow_3901U"></span>
+## Thone ThoneFlow-3901U
 
 > **Caution** This sensor is not yet supported - waiting on https://github.com/PX4/Firmware/pull/12148
 

--- a/en/sensor/px4flow.md
+++ b/en/sensor/px4flow.md
@@ -61,7 +61,8 @@ Flow data should be coming through at 10Hz if the autopilot is connected via **U
 Flow data is transmitted over wireless channels at a lower rate.
 
 
-### Mounting/Orientation {#mounting}
+<span id="mounting"></span>
+### Mounting/Orientation
 
 The recommended mounting orientation is defined as Y on flow board pointing towards **front of vehicle**, as shown in the following picture.
 
@@ -75,7 +76,8 @@ Make sure the the PX4Flow board is well dampened.
 > **Warning** PX4Flow emits a significant amount of electromagnetic radiation, and should be placed as far away from other electronics (in particular GPS modules) as possible (see [Hardware/issues/8](https://github.com/PX4/Hardware/issues/8) for more information).
   
 
-## PX4 Configuration {#px4_configuration}
+<span id="px4_configuration"></span>
+## PX4 Configuration
 
 The PX4Flow parameters that you may need to configure are listed below.
 
@@ -271,7 +273,8 @@ You can configure the image quality and output (the image output is only intende
 
   
 
-# PX4FLOW Developer Guide {#developer_guide}
+<span id="developer_guide"></span>
+# PX4FLOW Developer Guide
 
 ## Hardware Setup
 
@@ -436,7 +439,8 @@ VIDEO_RATE      | 50       | RW      | Time between images of video transmission
 
 ## Modes
 
-### VIDEO ONLY Mode {#VIDEO_ONLY}
+<span id="VIDEO_ONLY"></span>
+### VIDEO ONLY Mode
 
 Set `VIDEO_ONLY` to 1 for high resolution mode.
 In this mode the camera image is transmitted at a higher resolution to ease the lens focus process.

--- a/en/sensor/rangefinders.md
+++ b/en/sensor/rangefinders.md
@@ -63,7 +63,8 @@ It must be connected to a UART/serial bus.
 
 The [Avionics Anonymous UAVCAN Laser Altimeter Interface](../sensor/avanon_laser_interface.md) allows several common rangefinders (e.g. [Lightware SF11/c, SF30/D](../sensor/sfxx_lidar.md), etc) to be connected to the UAVCAN bus, a more robust interface than I2C.
 
-## Configuration/Setup {#configuration}
+<span id="configuration"></span>
+## Configuration/Setup
 
 Rangefinders are usually connected to either a serial (PWM) or I2C port (depending on the device driver), and are enabled on the port by setting a particular parameter.
 
@@ -84,7 +85,8 @@ These include (non exhaustively):
 - [EKF2_RNG_NOISE](../advanced_config/parameter_reference.md#EKF2_RNG_NOISE) - Measurement noise for range finder fusion
 
 
-## Testing {#testing}
+<span id="testing"></span>
+## Testing
 
 The easiest way to test the rangefinder is to vary the range and compare to the values detected by PX4. 
 The sections below show some approaches to getting the measured range.
@@ -119,7 +121,8 @@ listener distance_sensor 5
 For more information see: [Sensor/Topic Debugging using the Listener Command](https://dev.px4.io/master/en/debug/sensor_uorb_topic_debugging.html) (PX4 Development Guide).
 
 
-## Simulation {#simulation}
+<span id="simulation"></span>
+## Simulation
 
 Lidar and sonar rangefinders can be used in the [Gazebo Simulator](https://dev.px4.io/master/en/simulation/gazebo.html) (PX4 Development Guide).
 To do this you must start the simulator using a vehicle model that includes the rangefinder.

--- a/en/sensor/sfxx_lidar.md
+++ b/en/sensor/sfxx_lidar.md
@@ -33,7 +33,8 @@ SF10/C | 100m | Serial or I2C
 
 Check the tables above to confirm that which models can be connected to the I2C port.
 
-### Hardware {#i2c_hardware_setup}
+<span id="i2c_hardware_setup"></span>
+### Hardware
 
 Connect the Lidar the autopilot I2C port as shown below (in this case, for the [Pixhawk 1](../flight_controller/mro_pixhawk.md)).
 
@@ -44,20 +45,23 @@ Connect the Lidar the autopilot I2C port as shown below (in this case, for the [
 > On Linux systems you may be able to determine the address using [i2cdetect](http://manpages.ubuntu.com/manpages/bionic/en/man8/i2cdetect.8.html).
 > If the I2C address is equal to `0x66` the sensor can be used with PX4.
 
-### Parameter Setup {#i2c_parameter_setup}
+<span id="i2c_parameter_setup"></span>
+### Parameter Setup
 
 Set the [SENS_EN_SF1XX](../advanced_config/parameter_reference.md#SENS_EN_SF1XX) parameter to match the rangefinder model and then reboot.
 
 
 ## Serial Setup
 
-### Hardware {#serial_hardware_setup}
+<span id="serial_hardware_setup"></span>
+### Hardware
 
 The lidar can be connected to any unused *serial port* (UART), e.g.: TELEM2, TELEM3, GPS2 etc.
 
 <!-- Would be good to show serial setup! -->
 
-### Parameter Setup {#serial_parameter_setup}
+<span id="serial_parameter_setup"></span>
+### Parameter Setup
 
 [Configure the serial port](../peripherals/serial_configuration.md) on which the lidar will run using [SENS_SF0X_CFG](../advanced_config/parameter_reference.md#SENS_SF0X_CFG).
 There is no need to set the baud rate for the port, as this is configured by the driver.

--- a/en/telemetry/esp8266_wifi_module.md
+++ b/en/telemetry/esp8266_wifi_module.md
@@ -76,7 +76,8 @@ From the ESP8266, I left two wires connected to GPIO-0 and CH_PD free so I can b
 ![esp8266 flashing](../../assets/hardware/telemetry/esp8266_flashing_ftdi.jpg)
 
 
-## Pixhawk/PX4 Setup & Configuration {#px4_config}
+<span id="px4_config"></span>
+## Pixhawk/PX4 Setup & Configuration
 
 > **Tip** If using PX4 1.8.2 (and earlier) you should connect the ESP8266 to TELEM2 and configure the port by [setting the parameter](../advanced_config/parameters.md) `SYS_COMPANION` to 1921600 (remember to reboot after setting the parameter).
   The following instructions assume you are using PX4 versions after 1.8.2

--- a/en/telemetry/sik_radio.md
+++ b/en/telemetry/sik_radio.md
@@ -11,7 +11,8 @@ Hardware for the SiK radio can be obtained from various manufacturers/stores in 
 
 ![SiK Radio](../../assets/hardware/telemetry/holybro_sik_radio.jpg)
 
-## Vendors {#vendors}
+<span id="vendors"></span>
+## Vendors
 
 * [RFD900 Telemetry Radio](../telemetry/rfd900_telemetry.md)
 * [HKPilot Telemetry Radio](../telemetry/hkpilot_sik_radio.md)


### PR DESCRIPTION
this work is prep to migrating to another static site generator.

The user guide uses syntax like below to explicitly set the heading anchor:
```
## Some heading {#the_heading_anchor}
```
On gitbook this sets the anchor as specified. However this anchor does not work in github or most other SSGs. To fix this case I have replaced all the heading anchors with:
```
<span id="the_heading_anchor"></span>
## Some heading
```
This should work in any SSG.