### PR TITLE
Replace cmd with bash for code block

### DIFF
--- a/en/advanced_config/bootloader_update.md
+++ b/en/advanced_config/bootloader_update.md
@@ -39,11 +39,11 @@ The following steps explain how you can "manually" update the bootloader using t
 1. Get a binary containing the bootloader (either from dev team or build it yourself).
 1. Connect the Dronecode probe to your PC via USB. 
 1. Go into the directory containing the binary and run the following command in the terminal:
-   ```cmd
+   ```bash
    arm-none-eabi-gdb px4fmuv5_bl.elf
    ```
 1. The *gdb terminal* appears and it should display the following output:
-   ```cmd
+   ```bash
 GNU gdb (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 8.0.50.20171128-git
 Copyright (C) 2017 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

--- a/en/advanced_config/compass_power_compensation.md
+++ b/en/advanced_config/compass_power_compensation.md
@@ -36,7 +36,7 @@ Performing this power compensation is advisable only if all the following statem
    - Disarm the vehicle
    > **Note** Perform the test carefully and closely monitor the vibrations.
 1. Retrieve the ulog and use the python script [mag_compensation.py](https://github.com/PX4/Firmware/blob/master/src/lib/mag_compensation/python/mag_compensation.py) to identify the compensation parameters.
-   ```cmd
+   ```bash
    python mag_compensation.py ~/path/to/log/logfile.ulg
    ```
 


### PR DESCRIPTION
The syntax ```cmd for highlighting a code block does not work in vuepress (yet). Changing to ```bash as that works fine, and the syntax highlighting is almost identical.