### PR TITLE
Add FC page warnings to ask manufacturer about compliance

### DIFF
--- a/en/assembly/quick_start_cuav_v5_nano.md
+++ b/en/assembly/quick_start_cuav_v5_nano.md
@@ -1,5 +1,8 @@
 # CUAV V5 nano Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+
 This quick start guide shows how to power the [CUAV V5 nano](../flight_controller/cuav_v5_nano.md) flight controller and connect its most important peripherals.
 
 ![Nano Hero Image](../../assets/flight_controller/cuav_v5_nano/v5_nano_01.png)

--- a/en/assembly/quick_start_cuav_v5_plus.md
+++ b/en/assembly/quick_start_cuav_v5_plus.md
@@ -1,5 +1,8 @@
 # CUAV V5+ Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+
 This quick start guide shows how to power the [CUAV V5+](../flight_controller/cuav_v5_plus.md) flight controller and connect its most important peripherals.
  
 ![V5+ AutoPilot - Hero Image](../../assets/flight_controller/cuav_v5_plus/v5+_01.png)

--- a/en/assembly/quick_start_cube.md
+++ b/en/assembly/quick_start_cube.md
@@ -1,5 +1,8 @@
 # Cube Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://cubepilot.org/#/home) for support or compliance issues.
+
 This quick start guide shows how to power the *Cube*<sup>&reg;</sup> flight controllers and connect their most important peripherals.
 
 <img src="../../assets/flight_controller/cube/orange/cube_orange_hero.jpg" width="350px" /> <img src="../../assets/flight_controller/cube/cube_black_hero.png" width="350px" /> <img src="../../assets/flight_controller/cube/yellow/cube_yellow_hero.jpg" width="150px" />

--- a/en/assembly/quick_start_durandal.md
+++ b/en/assembly/quick_start_durandal.md
@@ -1,5 +1,8 @@
 # Durandal Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 This quick start guide shows how to power the Holybro [Durandal](../flight_controller/durandal.md)<sup>&reg;</sup> flight controller and connect its most important peripherals.
 
 ![Durandal](../../assets/flight_controller/durandal/durandal_hero.jpg)

--- a/en/assembly/quick_start_holybro_pix32_v5.md
+++ b/en/assembly/quick_start_holybro_pix32_v5.md
@@ -1,5 +1,8 @@
 # Pix32 v5 Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 This quick start guide shows how to power the [Holybro Pix32v5](../flight_controller/holybro_pix32_v5.md)<sup>&reg;</sup> flight controller and connect its most important peripherals.
 
 ![Pix32 v5 With Base](../../assets/flight_controller/holybro_pix32_v5/IMG_3165.jpg)

--- a/en/assembly/quick_start_pixhawk.md
+++ b/en/assembly/quick_start_pixhawk.md
@@ -1,5 +1,8 @@
 # Pixhawk Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
 This quick start guide shows how to power the *3DR Pixhawk* flight controller and connect its most important peripherals.
   
 ![Pixhawk Image](../../assets/flight_controller/pixhawk1/pixhawk_logo_view.jpg) 

--- a/en/assembly/quick_start_pixhawk4.md
+++ b/en/assembly/quick_start_pixhawk4.md
@@ -1,5 +1,8 @@
 # Pixhawk 4 Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 This quick start guide shows how to power the [Pixhawk 4](../flight_controller/pixhawk4.md)<sup>&reg;</sup> flight controller and connect its most important peripherals.
 
 <img src="../../assets/flight_controller/pixhawk4/pixhawk4_logo_view.jpg" width="420px" title="Pixhawk4 Image" /> 

--- a/en/assembly/quick_start_pixhawk4_mini.md
+++ b/en/assembly/quick_start_pixhawk4_mini.md
@@ -1,5 +1,8 @@
 # *Pixhawk 4 Mini* Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 This quick start guide shows how to power the [*Pixhawk<sup>&reg;</sup> 4 Mini*](../flight_controller/pixhawk4_mini.md) flight controller and connect its most important peripherals.
 
 ![Pixhawk4 mini](../../assets/flight_controller/pixhawk4mini/pixhawk4mini_iso_1.png)

--- a/en/assembly/quick_start_pixracer.md
+++ b/en/assembly/quick_start_pixracer.md
@@ -1,5 +1,9 @@
 # Pixracer Wiring Quick Start
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+  
+<span></span>
 > **Warning** Under construction.
 
 This quick start guide shows how to power the [Pixracer](../flight_controller/pixracer.md) flight controller and connect its most important peripherals.

--- a/en/complete_vehicles/crazyflie2.md
+++ b/en/complete_vehicles/crazyflie2.md
@@ -1,5 +1,9 @@
 # Crazyflie 2.0
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://www.bitcraze.io/) for support or compliance issues.
+  
+<span></span>
 > **Warning** PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 
 The Crazyflie line of micro quads was created by Bitcraze AB.An overview of the Crazyflie 2.0 can be [found here](https://www.bitcraze.io/crazyflie-2/).

--- a/en/flight_controller/auav_x2.md
+++ b/en/flight_controller/auav_x2.md
@@ -1,5 +1,9 @@
 # AUAV-X2 Autopilot (Discontinued)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
+<span></span>
 > **Warning** This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 
 The [AUAV<sup>&reg;</sup>](http://www.auav.com/) *AUAV-X2 autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/en/flight_controller/beaglebone_blue.md
+++ b/en/flight_controller/beaglebone_blue.md
@@ -1,5 +1,9 @@
 # BeagleBone Blue
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://beagleboard.org/blue) for support or compliance issues.
+
+<span></span>
 > **Warning** PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 
 [BeagleBone Blue](https://beagleboard.org/blue) is an all-in-one Linux-based computer.

--- a/en/flight_controller/cuav_v5.md
+++ b/en/flight_controller/cuav_v5.md
@@ -1,5 +1,9 @@
 # CUAV v5 (Discontinued)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+  
+<span></span>
 > **Warning** This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 
 *CUAV v5*<sup>&reg;</sup> (previously "Pixhack v5") is an advanced autopilot designed and made by CUAV<sup>&reg;</sup>. 

--- a/en/flight_controller/cuav_v5_nano.md
+++ b/en/flight_controller/cuav_v5_nano.md
@@ -1,5 +1,8 @@
 # CUAV V5 nano Autopilot
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+
 **V5 nano**<sup>&reg;</sup> is an autopilot for space-constrained applications, designed by CUAV<sup>&reg;</sup> in collaboration with the PX4 team.
 
 The autopilot is small enough to use in 220mm racing drones, but remains powerful enough for most drone use.

--- a/en/flight_controller/cuav_v5_plus.md
+++ b/en/flight_controller/cuav_v5_plus.md
@@ -1,5 +1,8 @@
 # CUAV V5+ Autopilot
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+
 *V5+*<sup>&reg;</sup> is an advanced autopilot manufactured by CUAV<sup>&reg;</sup>.
 It was designed by CUAV<sup>&reg;</sup> in collaboration with the PX4 team.
 

--- a/en/flight_controller/cubepilot_cube_orange.md
+++ b/en/flight_controller/cubepilot_cube_orange.md
@@ -1,16 +1,20 @@
 # Cube Orange Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://cubepilot.org/#/home) for support or compliance issues.
+
 The [Cube Orange](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems. 
 
 ![Cube Orange](../../assets/flight_controller/cube/orange/cube_orange_hero.jpg)
-
-> **Tip** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
 For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
+> **Tip** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
+
+<span></span>
 > **Note** This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 
 ## Key Features

--- a/en/flight_controller/cubepilot_cube_yellow.md
+++ b/en/flight_controller/cubepilot_cube_yellow.md
@@ -1,16 +1,20 @@
 # Cube Yellow Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://cubepilot.org/#/home) for support or compliance issues.
+
 The [Cube Yellow](http://www.proficnc.com/61-system-kits2) flight controller is a flexible autopilot intended primarily for manufacturers of commercial systems. 
 
 ![Cube Yellow](../../assets/flight_controller/cube/yellow/cube_yellow_hero.jpg)
-
-> **Tip** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
 For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, while a carrier board for a racer could includes ESCs for the frame of the vehicle.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / backup.
 
+> **Tip** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
+
+<span></span>
 > **Note** This flight controller is [manufacturer supported](../flight_controller/autopilot_manufacturer_supported.md).
 
 ## Key Features

--- a/en/flight_controller/dropix.md
+++ b/en/flight_controller/dropix.md
@@ -1,5 +1,8 @@
 # DroPix Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.drotek.com/) for support or compliance issues.
+
 The Drotek<sup>&reg;</sup> *DroPix autopilot* is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs the PX4 Flight Stack on the [NuttX](http://nuttx.org) OS.
 
 The DroPix system includes integrated multithreading, a Unix/Linux-like programming environment, completely new autopilot functions such as Lua scripting of missions and flight behavior, and a custom PX4 driver layer ensuring tight timing across all processes.

--- a/en/flight_controller/durandal.md
+++ b/en/flight_controller/durandal.md
@@ -1,5 +1,8 @@
 # Holybro Durandal
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 *Durandal*<sup>&reg;</sup> is the latest update to the successful family of Holybro flight controllers. 
 It was designed and developed by Holybro.
 

--- a/en/flight_controller/holybro_pix32.md
+++ b/en/flight_controller/holybro_pix32.md
@@ -1,5 +1,8 @@
 # Holybro pix32 Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 The Holybro<sup>&reg;</sup> [pix32 autopilot](https://shop.holybro.com/c/pixhawk-2_0460) (also known as "Pixhawk 2", and formerly as HKPilot32) is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design.
 This board is based on hardware version Pixhawk 2.4.6.
 It runs the PX4 flight stack on the [NuttX](http://nuttx.org) OS.

--- a/en/flight_controller/holybro_pix32_v5.md
+++ b/en/flight_controller/holybro_pix32_v5.md
@@ -1,5 +1,8 @@
 # Holybro Pix32 v5
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 [Pix32 v5](https://shop.holybro.com/pix32-v5_p1218.html)<sup>&reg;</sup> is an advanced autopilot flight controller designed and made by Holybro<sup>&reg;</sup>.
 It is optimized to run on PX4 firmware, which is intended for both academic and commercial developers.
 It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv5** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.

--- a/en/flight_controller/kakutef7.md
+++ b/en/flight_controller/kakutef7.md
@@ -1,5 +1,8 @@
 # Kakute F7
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 The *Kakute F7* from Holybro is a flight controller board designed for racers.
 
 <img src="../../assets/flight_controller/kakutef7/board.jpg" width="400px" title="Kakute F7" />

--- a/en/flight_controller/mindpx.md
+++ b/en/flight_controller/mindpx.md
@@ -1,5 +1,8 @@
 # MindPX Hardware
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](http://mindpx.net) for support or compliance issues.
+
 The AirMind<sup>&reg;</sup> [MindPX](http://mindpx.net) series is a new generation autopilot system branched from Pixhawk<sup>&reg;</sup>.
 
 ![MindPX Controller](../../assets/hardware/hardware-mindpx.png)

--- a/en/flight_controller/mindracer.md
+++ b/en/flight_controller/mindracer.md
@@ -1,5 +1,8 @@
 # MindRacer Hardware
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](http://mindpx.net) for support or compliance issues.
+
 The AirMind<sup>&reg;</sup> [MindRacer](http://mindpx.net) series is a fully stackable flight *platform* for miniature UAVs.
 The platform currently has two RTF vehicles: [MindRacer 210](../complete_vehicles/mindracer210.md) and [NanoMind 110](../complete_vehicles/nanomind110.md).
 

--- a/en/flight_controller/modalai_fc_v1.md
+++ b/en/flight_controller/modalai_fc_v1.md
@@ -1,5 +1,8 @@
 # ModalAI Flight Core v1
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://forum.modalai.com/) for support or compliance issues.
+
 The ModalAI [Flight Core v1](https://modalai.com/flight-core) ([Datasheet](https://docs.modalai.com/flight-core-datasheet)) is a flight controller for PX4, made in the USA.
 The Flight Core can be paired with ModalAI [VOXL](https://modalai.com/voxl) ([Datasheet](https://docs.modalai.com/voxl-datasheet/)) for obstacle avoidance and GPS-denied navigation, or used independently as a standalone flight controller.
 

--- a/en/flight_controller/mro_control_zero_f7.md
+++ b/en/flight_controller/mro_control_zero_f7.md
@@ -1,5 +1,8 @@
 # mRo Control Zero F7 Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
 The *mRo Control Zero F7<sup>&reg;</sup>* is a new flight controller from mRo.
 
 ![mRo Control Zero F7](../../assets/flight_controller/mro_control_zero_f7/mro_control_zero_f7.jpg)

--- a/en/flight_controller/mro_pixhawk.md
+++ b/en/flight_controller/mro_pixhawk.md
@@ -1,5 +1,8 @@
 # mRo Pixhawk Flight Controller (Pixhawk 1)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
 The *mRo Pixhawk<sup>&reg;</sup>* is a hardware compatible version of the original [Pixhawk 1](../flight_controller/pixhawk.md).  It runs PX4 on the [NuttX](http://nuttx.org) OS. 
 
 > **Tip** The controller can be used as a drop-in replacement for the 3DR<sup>&reg;</sup> [Pixhawk 1](../flight_controller/pixhawk.md).

--- a/en/flight_controller/mro_x2.1.md
+++ b/en/flight_controller/mro_x2.1.md
@@ -1,5 +1,8 @@
 # mRo-X2.1 Autopilot
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
 The [mRo-X2.1 autopilot](http://www.mRobotics.io/) is based on the [Pixhawk<sup>&reg;</sup>-project](https://pixhawk.org/) **FMUv2** open hardware design. It runs PX4 on the [NuttX](http://nuttx.org) OS.
 
 ![mRo X2.1](../../assets/flight_controller/mro/mro_x2.1.jpg)

--- a/en/flight_controller/nxp_rddrone_fmuk66.md
+++ b/en/flight_controller/nxp_rddrone_fmuk66.md
@@ -1,5 +1,8 @@
 # NXP RDDRONE-FMUK66 FMU
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://www.nxp.com/) for support or compliance issues.
+
 RDDRONE-FMUK66 FMU is a reference design using NXP Semiconductor components that closely follows Pixhawk FMUv4 specifications while adding two wire automotive Ethernet 100BASET1 and secure element A71CH (RevC) or SE050 (RevD).
 NXP provides the schematics, gerbers, BOM and source files so that anyone can duplicate, change or repurpose this design.
 

--- a/en/flight_controller/ocpoc_zynq.md
+++ b/en/flight_controller/ocpoc_zynq.md
@@ -1,5 +1,9 @@
 # Aerotenna OcPoC-Zynq Mini Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://ainstein.ai/) for support or compliance issues.
+
+<span></span>
 > **Warning** PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 
 The [OcPoC-Zynq Mini](https://aerotenna.readme.io/docs/ocpoc-mini-zynq-specifications) is a FPGA+ARM SoC based flight control platform.

--- a/en/flight_controller/omnibus_f4_sd.md
+++ b/en/flight_controller/omnibus_f4_sd.md
@@ -1,5 +1,8 @@
 # Omnibus F4 SD
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the manufacturer for support or compliance issues.
+
 The *Omnibus F4 SD* is a controller board designed for racers. 
 In contrast to a typical racer board it has some additional features, such as an SD card and a faster CPU.
 

--- a/en/flight_controller/pixfalcon.md
+++ b/en/flight_controller/pixfalcon.md
@@ -1,5 +1,9 @@
 # Pixfalcon Flight Controller (Discontinued)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+  
+<span></span>
 > **Warning** This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 
 The Pixfalcon autopilot (designed by [Holybro<sup>&reg;</sup>](http://www.holybro.com/)) is binary-compatible (FMUv2) derivative of the [Pixhawk 1](../flight_controller/pixhawk.md) design that has been optimized for space-constrained applications such as FPV racers. It has less IO to allow for the reduction in size.

--- a/en/flight_controller/pixhack_v3.md
+++ b/en/flight_controller/pixhack_v3.md
@@ -1,5 +1,8 @@
 # Pixhack V3
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.cuav.net/) for support or compliance issues.
+
 The CUAV *Pixhack V3* flight controller board is a flexible autopilot intended primarily for manufacturers of commercial systems.
 
 The board is a variant of the SOLO Pixhawk<sup>&reg;</sup> 2 (PH2) flight controller, which is in turn based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design.

--- a/en/flight_controller/pixhawk-2.md
+++ b/en/flight_controller/pixhawk-2.md
@@ -1,17 +1,20 @@
 # Hex Cube Black Flight Controller
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://cubepilot.org/#/home) for support or compliance issues.
+
 The [Hex Cube Black](http://www.proficnc.com/61-system-kits2) flight controller (previously known as Pixhawk 2.1) is a flexible autopilot intended primarily for manufacturers of commercial systems. 
 It is based on the [Pixhawk-project](https://pixhawk.org/) **FMUv3** open hardware design and runs PX4 on the [NuttX](http://nuttx.org) OS.
 
 ![Cube Black](../../assets/flight_controller/cube/cube_black_hero.png)
-
-> **Tip** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
 
 The controller is designed to be used with a domain-specific carrier board in order to reduce the wiring, improve reliability, and ease of assembly.
 For example, a carrier board for a commercial inspection vehicle might include connections for a companion computer, 
 while a carrier board for a racer could includes ESCs form the frame of the vehicle.
 
 Cube includes vibration isolation on two of the IMU's, with a third fixed IMU as a reference / Backup.
+
+> **Note** The manufacturer [Cube Docs](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview) contain detailed information, including an overview of the [Differences between Cube Colours](https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview#differences-between-cube-colours).
 
 > **Tip** This autopilot is [supported](../flight_controller/autopilot_pixhawk_standard.md) by the PX4 maintenance and test teams.
 

--- a/en/flight_controller/pixhawk.md
+++ b/en/flight_controller/pixhawk.md
@@ -1,5 +1,8 @@
 # 3DR Pixhawk 1 Flight Controller (Discontinued)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the manufacturer for support or compliance issues.
+
 > **Warning** This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
   You can use the [mRo Pixhawk](../flight_controller/mro_pixhawk.md) as a drop-in replacement.
 

--- a/en/flight_controller/pixhawk3_pro.md
+++ b/en/flight_controller/pixhawk3_pro.md
@@ -1,5 +1,8 @@
 # Pixhawk 3 Pro
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store-drotek.com/) for support or compliance issues.
+
 The Pixhawk<sup>&reg;</sup> 3 Pro is based on the FMUv4 hardware design (Pixracer) with some upgrades and additional features.
 The board was designed by [Drotek<sup>&reg;</sup>](https://drotek.com) and PX4.
 

--- a/en/flight_controller/pixhawk4.md
+++ b/en/flight_controller/pixhawk4.md
@@ -1,5 +1,8 @@
 # Pixhawk 4
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 *Pixhawk 4*<sup>&reg;</sup> is an advanced autopilot designed and made in collaboration with Holybro<sup>&reg;</sup> and the PX4 team.
 It is optimized to run PX4 v1.7 and later, and is suitable for academic and commercial developers.
 

--- a/en/flight_controller/pixhawk4_mini.md
+++ b/en/flight_controller/pixhawk4_mini.md
@@ -1,5 +1,8 @@
 # Pixhawk 4 Mini
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 The *Pixhawk<sup>&reg;</sup> 4 Mini* autopilot is designed for engineers and hobbyists who are looking to tap into the power of *Pixhawk 4* but are working with smaller drones.
 *Pixhawk 4 Mini* takes the FMU processor and memory resources from the *Pixhawk 4* while eliminating interfaces that are normally unused.
 This allows the *Pixhawk 4 Mini* to be small enough to fit in a 250mm racer drone.

--- a/en/flight_controller/pixhawk_mini.md
+++ b/en/flight_controller/pixhawk_mini.md
@@ -1,5 +1,8 @@
 # Holybro Pixhawk Mini
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.holybro.com/) for support or compliance issues.
+
 The Holybro *Pixhawk<sup>&reg;</sup> Mini* autopilot is a next-generation evolution of the Pixhawk.
 It is about 1/3rd the size of the original Pixhawk and has more powerful processors and sensors.
 

--- a/en/flight_controller/pixracer.md
+++ b/en/flight_controller/pixracer.md
@@ -1,6 +1,10 @@
-# Pixracer
+# mRo Pixracer
 
-The Pixhawk<sup>&reg;</sup> XRacer board family is optimized for small racing quads and planes. In contrast to [Pixfalcon](../flight_controller/pixfalcon.md) and [Pixhawk](../flight_controller/pixhawk.md) it has in-built Wifi, new sensors, convenient full servo headers, CAN and supports 2M flash.
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://store.mrobotics.io/) for support or compliance issues.
+
+The Pixhawk<sup>&reg;</sup> XRacer board family is optimized for small racing quads and planes.
+In contrast to [Pixfalcon](../flight_controller/pixfalcon.md) and [Pixhawk](../flight_controller/pixhawk.md) it has in-built Wifi, new sensors, convenient full servo headers, CAN and supports 2M flash.
 
 <img src="../../assets/flight_controller/pixracer/pixracer_hero_grey.jpg" width="300px" title="pixracer + 8266 grey" />
 

--- a/en/flight_controller/raspberry_pi_navio2.md
+++ b/en/flight_controller/raspberry_pi_navio2.md
@@ -1,5 +1,9 @@
 # Raspberry Pi 2/3 Navio2 Autopilot
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://emlid.com/) for support or compliance issues.
+
+<span></span>
 > **Warning** PX4 support for this flight controller is [experimental](../flight_controller/autopilot_experimental.md).
 
 ![Ra Pi Image](../../assets/hardware/hardware-rpi2.jpg)

--- a/en/flight_controller/snapdragon_flight.md
+++ b/en/flight_controller/snapdragon_flight.md
@@ -1,5 +1,9 @@
 # Snapdragon Flight Autopilot (Discontinued)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://www.intrinsyc.com/) for support or compliance issues.
+
+<span></span>
 > **Warning** This flight controller has been [discontinued](../flight_controller/autopilot_experimental.md) and is no longer commercially available.
 
 The *Qualcomm Snapdragon Flight* platform is a high-end autopilot / onboard computer which runs the PX4 Flight Stack on the DSP on the QuRT real time operating system using the [DSPAL API](https://github.com/ATLFlight/dspal) for POSIX compatibility. 

--- a/en/flight_controller/spracingh7extreme.md
+++ b/en/flight_controller/spracingh7extreme.md
@@ -1,5 +1,8 @@
 # SPRacingH7EXTREME (PX4 Edition)
 
+> **Warning** PX4 does not manufacture this (or any) autopilot.
+  Contact the [manufacturer](https://shop.seriouslypro.com) for support or compliance issues.
+
 The [SPRacingH7EXTREME](https://shop.seriouslypro.com/sp-racing-h7-extreme) is a feature packed FC/PDB with DUAL ICM20602 gyros, H7 400/480Mhz(+) CPU, high-precision BMP388 barometer, SD Card socket, current sensor, 8 easily accessible motor outputs, OSD, Microphone, Audio output, and more.
 
 It can be used easily for small to large quads, planes, octocoptors and more advanced frames.


### PR DESCRIPTION
This adds a warning up top of all flight controller and FC assembly pages that PX4 is not a manufacturer, and that manufacturer should be contacted for issues related to hardware support and compliance. 